### PR TITLE
MWPW-128696 - Github actions for milo-fg AIO app

### DIFF
--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        node-version: ['14']
+        node-version: ['16']
         os: [ubuntu-latest]
     steps:
       - name: Checkout
@@ -28,7 +28,7 @@ jobs:
       - name: Build
         env:
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_PROD }}
-        uses: adobe/aio-apps-action@2.0.1
+        uses: adobe/aio-apps-action@2.0.2
         with:
           os: ${{ matrix.os }}
           command: build
@@ -36,7 +36,10 @@ jobs:
         env:
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_PROD }}
           AIO_RUNTIME_AUTH: ${{ secrets.AIO_RUNTIME_AUTH_PROD }}
-        uses: adobe/aio-apps-action@2.0.1
+          FG_SITE: ${{ secrets.FG_SITE }}
+          FG_CLIENT_ID: ${{ secrets.FG_CLIENT_ID }}
+          FG_AUTHORITY: ${{ secrets.FG_AUTHORITY }}
+        uses: adobe/aio-apps-action@2.0.2
         with:
           os: ${{ matrix.os }}
           command: deploy

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        node-version: ['12']
+        node-version: ['14']
         os: [ubuntu-latest]
     steps:
       - name: Checkout
@@ -25,18 +25,6 @@ jobs:
         uses: adobe/aio-cli-setup-action@1.1.0
         with:
           os: ${{ matrix.os }}
-          version: 8.x.x
-      - name: Auth
-        uses: adobe/aio-apps-action@2.0.1
-        with:
-          os: ${{ matrix.os }}
-          command: auth
-          CLIENTID: ${{ secrets.CLIENTID_PROD }}
-          CLIENTSECRET: ${{ secrets.CLIENTSECRET_PROD }}
-          TECHNICALACCOUNTID: ${{ secrets.TECHNICALACCID_PROD }}
-          IMSORGID: ${{ secrets.IMSORGID_PROD }}
-          SCOPES: ${{ secrets.SCOPES_PROD }}
-          KEY: ${{ secrets.KEY_PROD }}
       - name: Build
         env:
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_PROD }}
@@ -48,13 +36,8 @@ jobs:
         env:
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_PROD }}
           AIO_RUNTIME_AUTH: ${{ secrets.AIO_RUNTIME_AUTH_PROD }}
-          AIO_PROJECT_ID: ${{ secrets.AIO_PROJECT_ID_PROD }}
-          AIO_PROJECT_NAME: ${{ secrets.AIO_PROJECT_NAME_PROD }}
-          AIO_PROJECT_ORG_ID: ${{ secrets.AIO_PROJECT_ORG_ID_PROD }}
-          AIO_PROJECT_WORKSPACE_ID: ${{ secrets.AIO_PROJECT_WORKSPACE_ID_PROD }}
-          AIO_PROJECT_WORKSPACE_NAME: ${{ secrets.AIO_PROJECT_WORKSPACE_NAME_PROD }}
-          AIO_PROJECT_WORKSPACE_DETAILS_SERVICES: ${{ secrets.AIO_PROJECT_WORKSPACE_DETAILS_SERVICES_PROD }}
         uses: adobe/aio-apps-action@2.0.1
         with:
           os: ${{ matrix.os }}
           command: deploy
+          noPublish: true

--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        node-version: ['14']
+        node-version: ['16']
         os: [ubuntu-latest]
     steps:
       - name: Checkout
@@ -29,7 +29,7 @@ jobs:
       - name: Build
         env:
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_STAGE }}
-        uses: adobe/aio-apps-action@2.0.1
+        uses: adobe/aio-apps-action@2.0.2
         with:
           os: ${{ matrix.os }}
           command: build
@@ -37,6 +37,9 @@ jobs:
         env:
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_STAGE }}
           AIO_RUNTIME_AUTH: ${{ secrets.AIO_RUNTIME_AUTH_STAGE }}
+          FG_SITE: ${{ secrets.FG_SITE }}
+          FG_CLIENT_ID: ${{ secrets.FG_CLIENT_ID }}
+          FG_AUTHORITY: ${{ secrets.FG_AUTHORITY }}
         uses: adobe/aio-apps-action@2.0.1
         with:
           os: ${{ matrix.os }}

--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        node-version: ['12']
+        node-version: ['14']
         os: [ubuntu-latest]
     steps:
       - name: Checkout
@@ -26,18 +26,6 @@ jobs:
         uses: adobe/aio-cli-setup-action@1.1.0
         with:
           os: ${{ matrix.os }}
-          version: 8.x.x
-      - name: Auth
-        uses: adobe/aio-apps-action@2.0.1
-        with:
-          os: ${{ matrix.os }}
-          command: auth
-          CLIENTID: ${{ secrets.CLIENTID_STAGE }}
-          CLIENTSECRET: ${{ secrets.CLIENTSECRET_STAGE }}
-          TECHNICALACCOUNTID: ${{ secrets.TECHNICALACCID_STAGE }}
-          IMSORGID: ${{ secrets.IMSORGID_STAGE }}
-          SCOPES: ${{ secrets.SCOPES_STAGE }}
-          KEY: ${{ secrets.KEY_STAGE }}
       - name: Build
         env:
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_STAGE }}
@@ -49,13 +37,8 @@ jobs:
         env:
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_STAGE }}
           AIO_RUNTIME_AUTH: ${{ secrets.AIO_RUNTIME_AUTH_STAGE }}
-          AIO_PROJECT_ID: ${{ secrets.AIO_PROJECT_ID_STAGE }}
-          AIO_PROJECT_NAME: ${{ secrets.AIO_PROJECT_NAME_STAGE }}
-          AIO_PROJECT_ORG_ID: ${{ secrets.AIO_PROJECT_ORG_ID_STAGE }}
-          AIO_PROJECT_WORKSPACE_ID: ${{ secrets.AIO_PROJECT_WORKSPACE_ID_STAGE }}
-          AIO_PROJECT_WORKSPACE_NAME: ${{ secrets.AIO_PROJECT_WORKSPACE_NAME_STAGE }}
-          AIO_PROJECT_WORKSPACE_DETAILS_SERVICES: ${{ secrets.AIO_PROJECT_WORKSPACE_DETAILS_SERVICES_STAGE }}
         uses: adobe/aio-apps-action@2.0.1
         with:
           os: ${{ matrix.os }}
           command: deploy
+          noPublish: true

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: ['14']
+        node-version: ['16']
         os: [ubuntu-latest]
     steps:
       - name: Checkout
@@ -25,12 +25,12 @@ jobs:
       - name: Build
         env:
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_STAGE }}
-        uses: adobe/aio-apps-action@2.0.1
+        uses: adobe/aio-apps-action@2.0.2
         with:
           os: ${{ matrix.os }}
           command: build
       - name: Test
-        uses: adobe/aio-apps-action@2.0.1
+        uses: adobe/aio-apps-action@2.0.2
         with:
           os: ${{ matrix.os }}
           command: test

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: ['12']
-        os: [macOS-latest, ubuntu-latest, windows-latest]
+        node-version: ['14']
+        os: [ubuntu-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -22,18 +22,6 @@ jobs:
         uses: adobe/aio-cli-setup-action@1.1.0
         with:
           os: ${{ matrix.os }}
-          version: 8.x.x
-      - name: Auth
-        uses: adobe/aio-apps-action@2.0.1
-        with:
-          os: ${{ matrix.os }}
-          command: auth
-          CLIENTID: ${{ secrets.CLIENTID_STAGE }}
-          CLIENTSECRET: ${{ secrets.CLIENTSECRET_STAGE }}
-          TECHNICALACCOUNTID: ${{ secrets.TECHNICALACCID_STAGE }}
-          IMSORGID: ${{ secrets.IMSORGID_STAGE }}
-          SCOPES: ${{ secrets.SCOPES_STAGE }}
-          KEY: ${{ secrets.KEY_STAGE }}
       - name: Build
         env:
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_STAGE }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 config.json
 .env*
 .aio
+14257-milofg-*.json
 
 # Adobe I/O console config
 console.json

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -5,6 +5,10 @@ application:
     packages:
       milo-fg:
         license: Apache-2.0
+        inputs:
+          fgSite: $FG_SITE
+          fgClientId: $FG_CLIENT_ID
+          fgAuthority: $FG_AUTHORITY
         actions:
           copy:
             function: actions/copy/copy.js


### PR DESCRIPTION
- slightly adjusted OOTB config to use node 16
- removed auth sections, not needed for standalone apps to be deployed
- required github secrets already added to the milofg repository for both stage and prod namespaces
- add generic FG specific secrets as environment variables to deployment actions
- inject env vars for actions on package level