### PR TITLE
MWPW-128696 - Github actions for milo-fg AIO app

### DIFF
--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -40,7 +40,7 @@ jobs:
           FG_SITE: ${{ secrets.FG_SITE }}
           FG_CLIENT_ID: ${{ secrets.FG_CLIENT_ID }}
           FG_AUTHORITY: ${{ secrets.FG_AUTHORITY }}
-        uses: adobe/aio-apps-action@2.0.1
+        uses: adobe/aio-apps-action@2.0.2
         with:
           os: ${{ matrix.os }}
           command: deploy


### PR DESCRIPTION
- update `aio-apps-action` version to v2.0.2 for deploy step

I forgot to update the `aio-apps-action` version from 2.0.1 to 2.0.2. Currently, the deploy to stage step fails due to https://github.com/adobe/aio-apps-action/pull/15 which was fixed in 2.0.2.