### PR TITLE
MWPW-128106: Bugfix - getConfig is not a function

### DIFF
--- a/actions/promote/worker.js
+++ b/actions/promote/worker.js
@@ -18,10 +18,10 @@
 const fetch = require('node-fetch');
 const { getConfig } = require('../config');
 const {
-    getAuthorizedRequestOption, createFolder, saveFile, updateExcelTable
+    getAuthorizedRequestOption, createFolder, saveFile, updateExcelTable, getFileUsingDownloadUrl
 } = require('../sharepoint');
 const {
-    getAioLogger, simulatePreview, handleExtension, getFile
+    getAioLogger, simulatePreview, handleExtension
 } = require('../utils');
 
 const BATCH_REQUEST_PROMOTE = 20;
@@ -136,7 +136,7 @@ async function promoteFloodgatedFiles(spToken, adminPageUri, projectExcelPath) {
             if (res.ok) {
                 // File exists at the destination (main content tree)
                 // Get the file in the pink directory using downloadUrl
-                const file = await getFile(downloadUrl);
+                const file = await getFileUsingDownloadUrl(downloadUrl);
                 if (file) {
                     // Save the file in the main content tree
                     const saveStatus = await saveFile(spToken, adminPageUri, file, filePath);

--- a/actions/sharepoint.js
+++ b/actions/sharepoint.js
@@ -83,6 +83,14 @@ async function getFile(doc) {
     return undefined;
 }
 
+async function getFileUsingDownloadUrl(downloadUrl) {
+    const response = await fetchWithRetry(downloadUrl);
+    if (response) {
+        return response.blob();
+    }
+    return undefined;
+}
+
 async function createFolder(spToken, adminPageUri, folder, isFloodgate) {
     const { sp } = await getConfig(adminPageUri);
     const options = getAuthorizedRequestOption(spToken, { method: sp.api.directory.create.method });
@@ -304,6 +312,7 @@ module.exports = {
     getAuthorizedRequestOption,
     getFilesData,
     getFile,
+    getFileUsingDownloadUrl,
     copyFile,
     saveFile,
     createFolder,

--- a/actions/utils.js
+++ b/actions/utils.js
@@ -17,7 +17,6 @@
 
 const AioLogger = require('@adobe/aio-lib-core-logging');
 const fetch = require('node-fetch');
-const { fetchWithRetry } = require('./sharepoint');
 
 const MAX_RETRIES = 5;
 
@@ -91,14 +90,6 @@ function handleExtension(path) {
     return path.substring(0, path.lastIndexOf('.'));
 }
 
-async function getFile(downloadUrl) {
-    const response = await fetchWithRetry(downloadUrl);
-    if (response) {
-        return response.blob();
-    }
-    return undefined;
-}
-
 function getPathFromUrl(url) {
     return new URL(url).pathname;
 }
@@ -128,6 +119,5 @@ module.exports = {
     getFloodgateUrl,
     simulatePreview,
     handleExtension,
-    getFile,
     getDocPathFromUrl
 };


### PR DESCRIPTION
The recent port of `fetchWithRetry` from Milo repo created a cyclical dependency introducing an issue where it was throwing `getConfig is not a function` as part of the promote action. 

Resolves: [MWPW-128106](https://jira.corp.adobe.com/browse/MWPW-128106)