### PR TITLE
MWPW-130038: Update to read config from env vars

### DIFF
--- a/actions/appConfig.js
+++ b/actions/appConfig.js
@@ -1,0 +1,36 @@
+/* ************************************************************************
+* ADOBE CONFIDENTIAL
+* ___________________
+*
+* Copyright 2023 Adobe
+* All Rights Reserved.
+*
+* NOTICE: All information contained herein is, and remains
+* the property of Adobe and its suppliers, if any. The intellectual
+* and technical concepts contained herein are proprietary to Adobe
+* and its suppliers and are protected by all applicable intellectual
+* property laws, including trade secret and copyright laws.
+* Dissemination of this information or reproduction of this material
+* is strictly forbidden unless prior written permission is obtained
+* from Adobe.
+************************************************************************* */
+
+class AppConfig {
+    appConfig = {};
+
+    setAppConfig(params) {
+        this.appConfig.fgSite = params.fgSite;
+        this.appConfig.fgClientId = params.fgClientId;
+        this.appConfig.fgAuthority = params.fgAuthority;
+        this.appConfig.shareUrl = params.shareUrl;
+        this.appConfig.fgShareUrl = params.fgShareUrl;
+        this.appConfig.rootFolder = params.rootFolder;
+        this.appConfig.fgRootFolder = params.fgRootFolder;
+    }
+
+    getConfig() {
+        return this.appConfig;
+    }
+}
+
+module.exports = new AppConfig();

--- a/actions/copy/worker.js
+++ b/actions/copy/worker.js
@@ -22,12 +22,14 @@ const {
 const {
     getAioLogger, simulatePreview, handleExtension, updateStatusToStateLib, COPY_ACTION
 } = require('../utils');
+const appConfig = require('../appConfig');
 
 const BATCH_REQUEST_COPY = 20;
 const DELAY_TIME_COPY = 3000;
 
 async function main(params) {
     const logger = getAioLogger();
+    appConfig.setAppConfig(params);
     let payload;
     const {
         spToken, adminPageUri, projectExcelPath, projectRoot

--- a/actions/promote/worker.js
+++ b/actions/promote/worker.js
@@ -23,6 +23,7 @@ const {
 const {
     getAioLogger, simulatePreview, handleExtension, updateStatusToStateLib, PROMOTE_ACTION
 } = require('../utils');
+const appConfig = require('../appConfig');
 
 const BATCH_REQUEST_PROMOTE = 20;
 const DELAY_TIME_PROMOTE = 3000;
@@ -30,6 +31,7 @@ const MAX_CHILDREN = 1000;
 
 async function main(params) {
     const logger = getAioLogger();
+    appConfig.setAppConfig(params);
     let payload;
     const {
         spToken, adminPageUri, projectExcelPath, projectRoot


### PR DESCRIPTION
This removes the multiple calls to getConfig() and multiple http fetch calls on the FG [config.json](https://main--milo--adobecom.hlx.page/drafts/floodgate/configs/config.json). 

The site, clientId and authority values that is part of the config.json is now part of github environment variables and is available in `params`. For local testing, you can manually add those values to the .env file in the project.

As it is not fetching the data from config.json in AIO, this also changes the API signature where `shareUrl`, `fgShareUrl`, `rootFolder` and `fgRootFolder` need to be passed in as part of the payload.

More details in the [wiki](https://wiki.corp.adobe.com/display/WP4/Milo+Floodgate+on+Adobe+IO).

Resolves: [MWPW-130038](https://jira.corp.adobe.com/browse/MWPW-130038)