### PR TITLE
MWPW-131233 : Adobe IO: Update file overwrite logic for COPY action

### DIFF
--- a/actions/copy/worker.js
+++ b/actions/copy/worker.js
@@ -85,11 +85,9 @@ async function floodgateContent(spToken, adminPageUri, projectExcelPath, project
             logger.info(`Copying ${srcPath} to pink folder`);
 
             let copySuccess = false;
-            if (urlInfo.doc.fg?.sp?.status !== 200) {
-                const destinationFolder = `${srcPath.substring(0, srcPath.lastIndexOf('/'))}`;
-                copySuccess = await copyFile(spToken, adminPageUri, srcPath, destinationFolder, undefined, true);
-            } else {
-                // Get the source file
+            const destinationFolder = `${srcPath.substring(0, srcPath.lastIndexOf('/'))}`;
+            copySuccess = await copyFile(spToken, adminPageUri, srcPath, destinationFolder, undefined, true);
+            if (copySuccess === false) {
                 const file = await getFile(urlInfo.doc);
                 if (file) {
                     const destination = urlInfo.doc.filePath;

--- a/actions/sharepoint.js
+++ b/actions/sharepoint.js
@@ -195,10 +195,8 @@ async function createSessionAndUploadFile(spToken, sp, file, dest, filename, isF
 }
 
 async function copyFile(spToken, adminPageUri, srcPath, destinationFolder, newName, isFloodgate, isFloodgateLockedFile) {
-    await createFolder(spToken, adminPageUri, destinationFolder, isFloodgate);
     const { sp } = await getConfig(adminPageUri);
-    const { baseURI } = sp.api.file.copy;
-    const { fgBaseURI } = sp.api.file.copy;
+    const { baseURI, fgBaseURI } = sp.api.file.copy;
     const rootFolder = isFloodgate ? fgBaseURI.split('/').pop() : baseURI.split('/').pop();
 
     const payload = { ...sp.api.file.copy.payload, parentReference: { path: `${rootFolder}${destinationFolder}` } };
@@ -212,7 +210,7 @@ async function copyFile(spToken, adminPageUri, srcPath, destinationFolder, newNa
     // In case of FG copy action triggered via saveFile(), locked file copy happens in the floodgate content location
     // So baseURI is updated to reflect the destination accordingly
     const contentURI = isFloodgate && isFloodgateLockedFile ? fgBaseURI : baseURI;
-    const copyStatusInfo = await fetchWithRetry(`${contentURI}${srcPath}:/copy`, options);
+    const copyStatusInfo = await fetchWithRetry(`${contentURI}${srcPath}:/copy?@microsoft.graph.conflictBehavior=replace`, options);
     const statusUrl = copyStatusInfo.headers.get('Location');
     let copySuccess = false;
     let copyStatusJson = {};


### PR DESCRIPTION
Link to the ticket: https://jira.corp.adobe.com/browse/MWPW-131233 
This ticket is an extension of a previous ticket (https://jira.corp.adobe.com/browse/MWPW-129539).

Right now, in copy action, saveFile() is called if the file exists at the destination. saveFile() makes several calls in order to handle locked files. The updated code in this PR calls saveFile() only if the file is locked or the folder is absent at the destination. Otherwise, it directly copies the file. This reduces the number of calls significantly.

The logs were verified for three scenarios: 
1. when the folders are already present in milo-pink
2. when the folder is absent in milo-pink
3. when the file is present in milo-pink and is locked 

This code is ported from the milo main repository. Link to the PR made to milo repository: https://github.com/adobecom/milo/pull/718 