### PR TITLE
MWPW-131427 - Authorization checks for Milo Floodgate Adobe I/O services

### DIFF
--- a/actions/appConfig.js
+++ b/actions/appConfig.js
@@ -41,6 +41,15 @@ class AppConfig {
         return this.configMap;
     }
 
+    getMsalConfig() {
+        const {
+            clientId, tenantId, certPassword, pvtKey, certThumbprint,
+        } = this.configMap;
+        return {
+            clientId, tenantId, certPassword, pvtKey, certThumbprint,
+        };
+    }
+
     extractPrivateKey() {
         if (!this.configMap.certKey) return;
         const decodedKey = Buffer.from(

--- a/actions/copy/copy.js
+++ b/actions/copy/copy.js
@@ -22,13 +22,14 @@ const {
     getAioLogger, updateStatusToStateLib, COPY_ACTION, getStatusFromStateLib
 } = require('../utils');
 const appConfig = require('../appConfig');
+const { isAuthorizedUser } = require('../sharepoint');
 
 // This returns the activation ID of the action that it called
 async function main(args) {
     const logger = getAioLogger();
     let payload;
     const {
-        adminPageUri, projectExcelPath, projectRoot
+        spToken, adminPageUri, projectExcelPath, projectRoot
     } = args;
     appConfig.setAppConfig(args);
     const projectPath = `${projectRoot}${projectExcelPath}`;
@@ -42,7 +43,11 @@ async function main(args) {
             logger.error(payload);
         } else {
             const storeValue = await getStatusFromStateLib(projectPath);
-            if (!appConfig.getSkipInProgressCheck() &&
+            const accountDtls = await isAuthorizedUser(spToken);
+            if (!accountDtls) {
+                payload = 'Could not determine the user.';
+                logger.error(payload);
+            } else if (!appConfig.getSkipInProgressCheck() &&
                 storeValue?.action?.status === PROJECT_STATUS.IN_PROGRESS) {
                 payload = 'A copy action project is already in progress.';
                 logger.error(payload);

--- a/actions/sharepoint.js
+++ b/actions/sharepoint.js
@@ -21,6 +21,7 @@ const { getConfig } = require('./config');
 const { getAioLogger } = require('./utils');
 const sharepointAuth = require('./sharepointAuth');
 
+const GRAPH_API = 'https://graph.microsoft.com/v1.0';
 const APP_USER_AGENT = 'ISV|Adobe|MiloFloodgate/0.1.0';
 const BATCH_REQUEST_LIMIT = 20;
 const BATCH_DELAY_TIME = 200;
@@ -53,6 +54,35 @@ async function getAuthorizedRequestOption({ body = null, json = true, method = '
     }
 
     return options;
+}
+
+async function getUserDetails(accessToken) {
+    const logger = getAioLogger();
+    try {
+        const headers = new Headers();
+        headers.append('Authorization', `Bearer ${accessToken}`);
+        headers.append('User-Agent', APP_USER_AGENT);
+        headers.append('Accept', 'application/json');
+
+        const response = await fetchWithRetry(`${GRAPH_API}/me`, { headers });
+
+        if (response?.ok) {
+            const user = await response.json();
+            logger.info('User details:');
+            logger.info(JSON.stringify(user));
+            return user;
+        }
+        logger.info(`Unable to get User details: ${response?.status}`);
+    } catch (error) {
+        logger.info('Unable to fetch User Info');
+        logger.info(JSON.stringify(error));
+    }
+    // Return null after verifications are done
+    return null;
+}
+
+async function isAuthorizedUser(accessToken) {
+    return getUserDetails(accessToken);
 }
 
 async function getFileData(adminPageUri, filePath, isFloodgate) {
@@ -332,6 +362,8 @@ function logHeaders(response) {
 
 module.exports = {
     getAuthorizedRequestOption,
+    isAuthorizedUser,
+    getUserDetails,
     getFilesData,
     getFile,
     getFileUsingDownloadUrl,

--- a/actions/sharepoint.js
+++ b/actions/sharepoint.js
@@ -78,7 +78,7 @@ async function getUserDetails(accessToken) {
         logger.info(JSON.stringify(error));
     }
     // Return null after verifications are done
-    return null;
+    return {};
 }
 
 async function isAuthorizedUser(accessToken) {

--- a/actions/sharepointAuth.js
+++ b/actions/sharepointAuth.js
@@ -28,19 +28,19 @@ const appConfig = require('./appConfig');
  */
 class SharepointAuth {
     init() {
-        const appCfg = appConfig.getConfig();
+        const msalConfig = appConfig.getMsalConfig();
 
         const missingConfigs = [];
-        if (!appCfg.clientId) {
+        if (!msalConfig.clientId) {
             missingConfigs.push('CLIENT_ID');
         }
-        if (!appCfg.tenantId) {
+        if (!msalConfig.tenantId) {
             missingConfigs.push('TENANT_ID');
         }
-        if (!appCfg.certThumbprint) {
+        if (!msalConfig.certThumbprint) {
             missingConfigs.push('CERT_THUMB_PRINT');
         }
-        if (!appCfg.pvtKey) {
+        if (!msalConfig.pvtKey) {
             missingConfigs.push('PRIVATE_KEY');
         }
         if (missingConfigs.length > 0) {
@@ -52,12 +52,12 @@ class SharepointAuth {
         }
         this.authConfig = {
             auth: {
-                clientId: appCfg.clientId,
-                authority: `https://login.microsoftonline.com/${appCfg.tenantId}`,
+                clientId: msalConfig.clientId,
+                authority: `https://login.microsoftonline.com/${msalConfig.tenantId}`,
                 knownAuthorities: ['login.microsoftonline.com'],
                 clientCertificate: {
-                    privateKey: appCfg.pvtKey,
-                    thumbprint: appCfg.certThumbprint,
+                    privateKey: msalConfig.certKey,
+                    thumbprint: msalConfig.certThumbprint,
                 },
             },
         };


### PR DESCRIPTION
One part of user story was to cover below
* To protect it further, pass in the Sharepoint access token when calling the AIO actions
* If access token is not available, do not trigger the async worker and return failure in the response with appropriate error message

Currently done by making a call to "https://graph.microsoft.com/v1.0/me" which would return valid user data, if the token is valid else would return 401. 

Check will be enabled as part of another PR

Resolves: MWPW-131427

Test - 
Following error is sent
{
    "Error": "Could not determine the user."
}
