### PR TITLE
MWPW-131233: Adobe IO Update file overwrite logic during copy

### DIFF
--- a/actions/copy/worker.js
+++ b/actions/copy/worker.js
@@ -87,11 +87,9 @@ async function floodgateContent(adminPageUri, projectExcelPath, projectDetail) {
             logger.info(`Copying ${srcPath} to pink folder`);
 
             let copySuccess = false;
-            if (urlInfo.doc.fg?.sp?.status !== 200) {
-                const destinationFolder = `${srcPath.substring(0, srcPath.lastIndexOf('/'))}`;
-                copySuccess = await copyFile(adminPageUri, srcPath, destinationFolder, undefined, true);
-            } else {
-                // Get the source file
+            const destinationFolder = `${srcPath.substring(0, srcPath.lastIndexOf('/'))}`;
+            copySuccess = await copyFile(adminPageUri, srcPath, destinationFolder, undefined, true);
+            if (copySuccess === false) {
                 const file = await getFile(urlInfo.doc);
                 if (file) {
                     const destination = urlInfo.doc.filePath;

--- a/actions/promote/worker.js
+++ b/actions/promote/worker.js
@@ -18,7 +18,7 @@
 const { getConfig } = require('../config');
 const { PROJECT_STATUS } = require('../project');
 const {
-    getAuthorizedRequestOption, createFolder, saveFile, updateExcelTable, getFileUsingDownloadUrl, fetchWithRetry
+    getAuthorizedRequestOption, saveFile, updateExcelTable, getFileUsingDownloadUrl, fetchWithRetry
 } = require('../sharepoint');
 const {
     getAioLogger, simulatePreview, handleExtension, updateStatusToStateLib, PROMOTE_ACTION, delay
@@ -109,18 +109,17 @@ async function findAllFloodgatedFiles(baseURI, options, rootFolder, fgFiles, fgF
  * Creates intermediate folders if needed.
  */
 async function promoteCopy(adminPageUri, srcPath, destinationFolder) {
-    await createFolder(adminPageUri, destinationFolder);
     const { sp } = await getConfig(adminPageUri);
-    const destRootFolder = `${sp.api.file.copy.baseURI}`.split('/').pop();
-
-    const payload = { ...sp.api.file.copy.payload, parentReference: { path: `${destRootFolder}${destinationFolder}` } };
+    const { baseURI } = sp.api.file.copy;
+    const rootFolder = baseURI.split('/').pop();
+    const payload = { ...sp.api.file.copy.payload, parentReference: { path: `${rootFolder}${destinationFolder}` } };
     const options = await getAuthorizedRequestOption({
         method: sp.api.file.copy.method,
         body: JSON.stringify(payload),
     });
 
     // copy source is the pink directory for promote
-    const copyStatusInfo = await fetchWithRetry(`${sp.api.file.copy.fgBaseURI}${srcPath}:/copy`, options);
+    const copyStatusInfo = await fetchWithRetry(`${sp.api.file.copy.fgBaseURI}${srcPath}:/copy?@microsoft.graph.conflictBehavior=replace`, options);
     const statusUrl = copyStatusInfo.headers.get('Location');
     let copySuccess = false;
     let copyStatusJson = {};
@@ -144,25 +143,16 @@ async function promoteFloodgatedFiles(adminPageUri, projectExcelPath) {
         try {
             let promoteSuccess = false;
             logger.info(`Promoting ${filePath}`);
-            const { sp } = await getConfig(adminPageUri);
-            const options = await getAuthorizedRequestOption();
-            const res = await fetchWithRetry(`${sp.api.file.get.baseURI}${filePath}`, options);
-            if (res.ok) {
-                // File exists at the destination (main content tree)
-                // Get the file in the pink directory using downloadUrl
-                const file = await getFileUsingDownloadUrl(downloadUrl);
-                if (file) {
-                    // Save the file in the main content tree
-                    const saveStatus = await saveFile(adminPageUri, file, filePath);
-                    if (saveStatus.success) {
-                        promoteSuccess = true;
-                    }
-                }
+            const destinationFolder = `${filePath.substring(0, filePath.lastIndexOf('/'))}`;
+            const copyFileStatus = await promoteCopy(adminPageUri, filePath, destinationFolder);
+            if (copyFileStatus) {
+                promoteSuccess = true;
             } else {
-                // File does not exist at the destination (main content tree)
-                // File can be copied directly
-                const destinationFolder = `${filePath.substring(0, filePath.lastIndexOf('/'))}`;
-                promoteSuccess = await promoteCopy(adminPageUri, filePath, destinationFolder);
+                const file = await getFileUsingDownloadUrl(downloadUrl);
+                const saveStatus = await saveFile(adminPageUri, file, filePath);
+                if (saveStatus.success) {
+                    promoteSuccess = true;
+                }
             }
             status.success = promoteSuccess;
             status.srcPath = filePath;

--- a/actions/sharepoint.js
+++ b/actions/sharepoint.js
@@ -203,10 +203,8 @@ async function createSessionAndUploadFile(sp, file, dest, filename, isFloodgate)
 }
 
 async function copyFile(adminPageUri, srcPath, destinationFolder, newName, isFloodgate, isFloodgateLockedFile) {
-    await createFolder(adminPageUri, destinationFolder, isFloodgate);
     const { sp } = await getConfig(adminPageUri);
-    const { baseURI } = sp.api.file.copy;
-    const { fgBaseURI } = sp.api.file.copy;
+    const { baseURI, fgBaseURI } = sp.api.file.copy;
     const rootFolder = isFloodgate ? fgBaseURI.split('/').pop() : baseURI.split('/').pop();
 
     const payload = { ...sp.api.file.copy.payload, parentReference: { path: `${rootFolder}${destinationFolder}` } };
@@ -220,7 +218,7 @@ async function copyFile(adminPageUri, srcPath, destinationFolder, newName, isFlo
     // In case of FG copy action triggered via saveFile(), locked file copy happens in the floodgate content location
     // So baseURI is updated to reflect the destination accordingly
     const contentURI = isFloodgate && isFloodgateLockedFile ? fgBaseURI : baseURI;
-    const copyStatusInfo = await fetchWithRetry(`${contentURI}${srcPath}:/copy`, options);
+    const copyStatusInfo = await fetchWithRetry(`${contentURI}${srcPath}:/copy?@microsoft.graph.conflictBehavior=replace`, options);
     const statusUrl = copyStatusInfo.headers.get('Location');
     let copySuccess = false;
     let copyStatusJson = {};
@@ -340,4 +338,6 @@ module.exports = {
     createFolder,
     updateExcelTable,
     fetchWithRetry,
+    getFolderFromPath,
+    getFileNameFromPath,
 };


### PR DESCRIPTION
Link to the ticket: https://jira.corp.adobe.com/browse/MWPW-131233

The PR does the following:

Right now, for promote and copy action, saveFile() is called if the file exists at the destination. saveFile() makes several calls in order to handle locked files. The updated code in this PR calls saveFile() only if the file is locked or the folder is absent at the destination. Otherwise, it directly copies the file. This reduces the number of calls significantly.

This PR contains code that is ported from the main milo repository. Link to previous ticket for main milo repository: https://jira.corp.adobe.com/browse/MWPW-129539