### PR TITLE
MWPW-131693: Remove GET calls to pink on copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ dist
 config.json
 .env*
 .aio
-14257-milofg-*.json
+milofg-14257-*.json
 
 # Adobe I/O console config
 console.json
@@ -28,6 +28,7 @@ junit.xml
 coverage
 .aws.tmp.creds.json
 .wskdebug.props.tmp
+web-src
 
 # Parcel
 .parcel-cache

--- a/actions/sharepoint.js
+++ b/actions/sharepoint.js
@@ -90,7 +90,9 @@ async function getFileData(adminPageUri, filePath, isFloodgate) {
     const baseURI = isFloodgate ? sp.api.directory.create.fgBaseURI : sp.api.directory.create.baseURI;
     const resp = await fetchWithRetry(`${baseURI}${filePath}`, options);
     const json = await resp.json();
-    return json;
+    const fileDownloadUrl = json['@microsoft.graph.downloadUrl'];
+    const fileSize = json.size;
+    return { fileDownloadUrl, fileSize };
 }
 
 async function getFilesData(adminPageUri, filePaths, isFloodgate) {
@@ -114,7 +116,7 @@ async function getFilesData(adminPageUri, filePaths, isFloodgate) {
 
 async function getFile(doc) {
     if (doc && doc.sp && doc.sp.status === 200) {
-        const response = await fetchWithRetry(doc.sp['@microsoft.graph.downloadUrl']);
+        const response = await fetchWithRetry(doc.sp.fileDownloadUrl);
         return response.blob();
     }
     return undefined;

--- a/actions/utils.js
+++ b/actions/utils.js
@@ -84,15 +84,6 @@ async function simulatePreview(path, retryAttempt = 1, isFloodgate, adminPageUri
     return previewStatus;
 }
 
-function getFloodgateUrl(url) {
-    if (!url) {
-        return undefined;
-    }
-    const urlArr = url.split('--');
-    urlArr[1] += '-pink';
-    return urlArr.join('--');
-}
-
 function handleExtension(path) {
     if (path.endsWith('.xlsx')) {
         return path.replace('.xlsx', '.json');
@@ -202,7 +193,6 @@ async function delay(milliseconds = 100) {
 module.exports = {
     getAioLogger,
     getUrlInfo,
-    getFloodgateUrl,
     simulatePreview,
     handleExtension,
     getDocPathFromUrl,


### PR DESCRIPTION
When COPY action is called, the code ported from the milo repo makes GET calls on both source and equivalent pink tree. This was done to render the data in the UI.

The GET calls on the pink tree made as part of "updateProjectWithDocs()" is not required for COPY operation in AIO and has been removed.

Resolves: [MWPW-131693](https://jira.corp.adobe.com/browse/MWPW-131693)