### PR TITLE
MWPW-128689 - Create folders before copy to floodgate

### DIFF
--- a/actions/project.js
+++ b/actions/project.js
@@ -106,8 +106,11 @@ async function updateProjectWithDocs(adminPageUri, projectDetail) {
     injectSharepointData(projectDetail.urls, filePaths, docPaths, spFiles);
 }
 
+const projectInProgress = (status) => [PROJECT_STATUS.IN_PROGRESS, PROJECT_STATUS.STARTED].includes(status);
+
 module.exports = {
     getProjectDetails,
     updateProjectWithDocs,
+    projectInProgress,
     PROJECT_STATUS
 };

--- a/actions/promote/worker.js
+++ b/actions/promote/worker.js
@@ -21,7 +21,7 @@ const {
     getAuthorizedRequestOption, saveFile, updateExcelTable, getFileUsingDownloadUrl, fetchWithRetry
 } = require('../sharepoint');
 const {
-    getAioLogger, simulatePreviewPublish, handleExtension, updateStatusToStateLib, PROMOTE_ACTION, delay, PREVIEW, PUBLISH
+    getAioLogger, simulatePreviewPublish, handleExtension, updateStatusToStateLib, PROMOTE_ACTION, delay, PREVIEW, PUBLISH, logMemUsage
 } = require('../utils');
 const appConfig = require('../appConfig');
 
@@ -31,6 +31,7 @@ const MAX_CHILDREN = 1000;
 
 async function main(params) {
     const logger = getAioLogger();
+    logMemUsage();
     let payload;
     const {
         adminPageUri, projectExcelPath, fgRootFolder, doPublish
@@ -233,7 +234,7 @@ async function promoteFloodgatedFiles(adminPageUri, projectExcelPath, doPublish)
         payload = 'Promoted floodgate tree successfully.';
         logger.info('Promoted floodgate tree successfully.');
     }
-
+    logMemUsage();
     payload = 'All tasks for Floodgate Promote completed';
     return payload;
 }

--- a/actions/sharepoint.js
+++ b/actions/sharepoint.js
@@ -67,10 +67,8 @@ async function getDriveRoot(accessToken) {
         const response = await fetchWithRetry(`${fgSite}/drive/root`, { headers });
 
         if (response?.ok) {
-            const user = await response.json();
-            logger.info('User details:');
-            logger.info(JSON.stringify(user));
-            return user;
+            const driveDtls = await response.json();
+            return driveDtls;
         }
         logger.info(`Unable to get User details: ${response?.status}`);
     } catch (error) {
@@ -136,7 +134,6 @@ async function createFolder(adminPageUri, folder, isFloodgate) {
     options.body = JSON.stringify(sp.api.directory.create.payload);
 
     const baseURI = isFloodgate ? sp.api.directory.create.fgBaseURI : sp.api.directory.create.baseURI;
-
     const res = await fetchWithRetry(`${baseURI}${folder}`, options);
     if (res.ok) {
         return res.json();
@@ -233,7 +230,45 @@ async function createSessionAndUploadFile(sp, file, dest, filename, isFloodgate)
     return status;
 }
 
+/**
+ * The method gets the list of files, extracts the parent path, extracts uniq paths,
+ * filters common parents urls
+ * e.g.. [/a/b/one.txt, /a/b/two.txt, /a/c/three.txt, /a/c/d/three.txt]
+ * Folders to create woouold be [/a/b, /a/c/d]
+ * This triggers async and waits for batch to complete. These are small batches so should be fast.
+ * The $batch can be used in future to submit only one URL
+ * @param {*} adminPageUri AdminPageURI for getting configs
+ * @param {*} srcPathList Paths of files for which folder creating is needed
+ * @param {*} isFloodgate Is floodgate flag
+ * @returns Create folder status
+ */
+async function bulkCreateFolders(adminPageUri, srcPathList, isFloodgate) {
+    const logger = getAioLogger();
+    const createtFolderStatuses = [];
+    const allPaths = srcPathList.map((e) => {
+        if (e.length < 2 || !e[1]?.doc) return '';
+        return getFolderFromPath(e[1].doc.filePath);
+    }).filter((e) => true && e);
+    const uniqPathLst = Array.from(new Set(allPaths));
+    const leafPathLst = uniqPathLst.filter((e) => uniqPathLst.findIndex((e1) => e1.indexOf(`${e}/`) >= 0) < 0);
+    // logger.info(`Unique path list ${JSON.stringify(leafPathLst)}`);
+    try {
+        logger.info('bulkCreateFolders started');
+        const promises = leafPathLst.map((folder) => createFolder(adminPageUri, folder, isFloodgate));
+        logger.info('Got createfolder promises and waiting....');
+        createtFolderStatuses.push(...await Promise.all(promises));
+        logger.info(`bulkCreateFolders completed ${createtFolderStatuses?.length}`);
+        // logger.info(`bulkCreateFolders statuses ${JSON.stringify(createtFolderStatuses)}`);
+    } catch (error) {
+        logger.info('Error while creating folders');
+        logger.info(error?.stack);
+    }
+    logger.info(`bulkCreateFolders returning ${createtFolderStatuses?.length}`);
+    return createtFolderStatuses;
+}
+
 async function copyFile(adminPageUri, srcPath, destinationFolder, newName, isFloodgate, isFloodgateLockedFile) {
+    const logger = getAioLogger();
     const { sp } = await getConfig(adminPageUri);
     const { baseURI, fgBaseURI } = sp.api.file.copy;
     const rootFolder = isFloodgate ? fgBaseURI.split('/').pop() : baseURI.split('/').pop();
@@ -253,6 +288,9 @@ async function copyFile(adminPageUri, srcPath, destinationFolder, newName, isFlo
     const statusUrl = copyStatusInfo.headers.get('Location');
     let copySuccess = false;
     let copyStatusJson = {};
+    if (!statusUrl) {
+        logger.info(`Copy of ${srcPath} returned ${copyStatusInfo?.status} with no followup URL`);
+    }
     while (statusUrl && !copySuccess && copyStatusJson.status !== 'failed') {
         // eslint-disable-next-line no-await-in-loop
         const status = await fetchWithRetry(statusUrl);
@@ -346,14 +384,18 @@ async function fetchWithRetry(apiUrl, options, retryCounts) {
     });
 }
 
+function getHeadersStr(response) {
+    const headers = {};
+    response?.headers?.forEach((value, name) => {
+        headers[name] = value;
+    });
+    return JSON.stringify(headers);
+}
+
 function logHeaders(response) {
     if (!LOG_RESP_HEADER) return;
     const logger = getAioLogger();
-    const headers = {};
-    response.headers.forEach((value, name) => {
-        headers[name] = value;
-    });
-    const hdrStr = JSON.stringify(headers);
+    const hdrStr = getHeadersStr(response);
     const logStr = `Status is ${response.status} with headers ${hdrStr}`;
 
     if (logStr.toUpperCase().indexOf('RATE') > 0 || logStr.toUpperCase().indexOf('RETRY') > 0) logger.info(logStr);
@@ -372,4 +414,5 @@ module.exports = {
     fetchWithRetry,
     getFolderFromPath,
     getFileNameFromPath,
+    bulkCreateFolders,
 };

--- a/actions/sharepoint.js
+++ b/actions/sharepoint.js
@@ -234,7 +234,7 @@ async function createSessionAndUploadFile(sp, file, dest, filename, isFloodgate)
  * The method gets the list of files, extracts the parent path, extracts uniq paths,
  * filters common parents urls
  * e.g.. [/a/b/one.txt, /a/b/two.txt, /a/c/three.txt, /a/c/d/three.txt]
- * Folders to create woouold be [/a/b, /a/c/d]
+ * Folders to create would be [/a/b, /a/c/d]
  * This triggers async and waits for batch to complete. These are small batches so should be fast.
  * The $batch can be used in future to submit only one URL
  * @param {*} adminPageUri AdminPageURI for getting configs

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -34,6 +34,7 @@ application:
               LOG_LEVEL: debug
             limits:
               timeout: 3600000
+              memorySize: 2048
           promote:
             function: actions/promote/promote.js
             web: 'yes'
@@ -48,6 +49,7 @@ application:
               LOG_LEVEL: debug
             limits:
               timeout: 3600000
+              memorySize: 2048
           status:
             function: actions/status/status.js
             web: 'yes'


### PR DESCRIPTION
When running large files copy to FG for new folders the copy fails due too folder did not exists and alternate path of pulling file content and copying is done. This causes high memory usages. Hence, updated to bulk create folders of the batch before copy for a batch starts. 
Along with state in progress, actual activation status is also checked, this might help to reprocess in case of activation is stopped/processing stops.
Memory limit for worker actions updated to 2048 mb

Resolve: MWPW-128689