### PR TITLE
MWPW-132593: Temporarily restrict promote to files under /drafts only

### DIFF
--- a/actions/promote/worker.js
+++ b/actions/promote/worker.js
@@ -89,7 +89,8 @@ async function findAllFiles() {
     const rootFolder = baseURI.split('/').pop();
     const options = await getAuthorizedRequestOption({ method: 'GET' });
 
-    return findAllFloodgatedFiles(baseURI, options, rootFolder, [], ['']);
+    // Temporarily restricting the iteration for promote to under /drafts folder only
+    return findAllFloodgatedFiles(baseURI, options, rootFolder, [], ['/drafts']);
 }
 
 /**


### PR DESCRIPTION
There was a recent incident where a metadata.xlsx file was added in `/milo-pink` root folder to test a feature for CaaS which inadvertently got promoted to `/milo` replacing the original file and creating some issue. 

So for testing purposes, temporarily forcing the promote to `/drafts` folder only.

Note that, even though the restriction is on `/drafts`, for testing purposes, continue to use your own folders under `/drafts`. i.e. `/drafts/<ldap-id>`

Resolves: [MWPW-132593](https://jira.corp.adobe.com/browse/MWPW-132593)