### PR TITLE
MWPW-131688: Added support for other drives

### DIFF
--- a/actions/appConfig.js
+++ b/actions/appConfig.js
@@ -32,7 +32,7 @@ class AppConfig {
         this.configMap.payload.fgRootFolder = params.fgRootFolder;
         this.configMap.payload.promoteIgnorePaths = params.promoteIgnorePaths || [];
         this.configMap.payload.doPublish = params.doPublish;
-        this.configMap.driveId = params.driveId;
+        this.configMap.payload.driveId = params.driveId;
 
         // These are from configs
         this.configMap.fgSite = params.fgSite;

--- a/actions/appConfig.js
+++ b/actions/appConfig.js
@@ -32,6 +32,7 @@ class AppConfig {
         this.configMap.payload.fgRootFolder = params.fgRootFolder;
         this.configMap.payload.promoteIgnorePaths = params.promoteIgnorePaths || [];
         this.configMap.payload.doPublish = params.doPublish;
+        this.configMap.driveId = params.driveId;
 
         // These are from configs
         this.configMap.fgSite = params.fgSite;

--- a/actions/config.js
+++ b/actions/config.js
@@ -25,8 +25,8 @@ function getSharepointConfig(applicationConfig) {
     const driveId = `${applicationConfig.driveId}`;
     const drive = driveId ? `/drives/${driveId}` : '/drive';
 
-    const baseURI = `${applicationConfig.fgSite}${drive}/root:${applicationConfig.rootFolder}`;
-    const fgBaseURI = `${applicationConfig.fgSite}${drive}/root:${applicationConfig.fgRootFolder}`;
+    const baseURI = `${applicationConfig.fgSite}${drive}/root:${applicationConfig.payload.rootFolder}`;
+    const fgBaseURI = `${applicationConfig.fgSite}${drive}/root:${applicationConfig.payload.fgRootFolder}`;
     return {
         ...applicationConfig,
         clientApp: {

--- a/actions/config.js
+++ b/actions/config.js
@@ -22,7 +22,7 @@ const GRAPH_API = 'https://graph.microsoft.com/v1.0';
 
 function getSharepointConfig(applicationConfig) {
     // get drive id if available
-    const driveId = `${applicationConfig.driveId}`;
+    const driveId = `${applicationConfig.payload.driveId}`;
     const drive = driveId ? `/drives/${driveId}` : '/drive';
 
     const baseURI = `${applicationConfig.fgSite}${drive}/root:${applicationConfig.payload.rootFolder}`;

--- a/actions/config.js
+++ b/actions/config.js
@@ -21,8 +21,12 @@ const urlInfo = require('./urlInfo');
 const GRAPH_API = 'https://graph.microsoft.com/v1.0';
 
 function getSharepointConfig(applicationConfig) {
-    const baseURI = `${applicationConfig.fgSite}/drive/root:${applicationConfig.payload.rootFolder}`;
-    const fgBaseURI = `${applicationConfig.fgSite}/drive/root:${applicationConfig.payload.fgRootFolder}`;
+    // get drive id if available
+    const driveId = `${applicationConfig.driveId}`;
+    const drive = driveId ? `/drives/${driveId}` : '/drive';
+
+    const baseURI = `${applicationConfig.fgSite}${drive}/root:${applicationConfig.rootFolder}`;
+    const fgBaseURI = `${applicationConfig.fgSite}${drive}/root:${applicationConfig.fgRootFolder}`;
     return {
         ...applicationConfig,
         clientApp: {
@@ -39,7 +43,7 @@ function getSharepointConfig(applicationConfig) {
             url: GRAPH_API,
             file: {
                 get: { baseURI, fgBaseURI },
-                download: { baseURI: `${applicationConfig.fgSite}/drive/items` },
+                download: { baseURI: `${applicationConfig.fgSite}${drive}/items` },
                 upload: {
                     baseURI,
                     fgBaseURI,


### PR DESCRIPTION
The change allows running MS Graph APIs on drives other than adobecom (eg: CC) although the E2E test on CC will require additional changes, some of which will be handled in MWPW-134759