### PR TITLE
MWPW-134759 Update/Get project excel updated to use driveItemId

### DIFF
--- a/actions/config.js
+++ b/actions/config.js
@@ -27,6 +27,8 @@ function getSharepointConfig(applicationConfig) {
 
     const baseURI = `${applicationConfig.fgSite}${drive}/root:${applicationConfig.payload.rootFolder}`;
     const fgBaseURI = `${applicationConfig.fgSite}${drive}/root:${applicationConfig.payload.fgRootFolder}`;
+    const baseItemsURI = `${applicationConfig.fgSite}${drive}/items`;
+    const fgBaseItemsURI = `${applicationConfig.fgSite}${drive}/items`;
     return {
         ...applicationConfig,
         clientApp: {
@@ -81,9 +83,10 @@ function getSharepointConfig(applicationConfig) {
                 },
             },
             excel: {
+                get: { baseItemsURI, fgBaseItemsURI },
                 update: {
-                    baseURI,
-                    fgBaseURI,
+                    baseItemsURI,
+                    fgBaseItemsURI,
                     method: 'POST',
                 },
             },

--- a/actions/promote/createBatch.js
+++ b/actions/promote/createBatch.js
@@ -107,7 +107,7 @@ async function main(params) {
  */
 async function createBatch(batchManager) {
     const { sp } = await getConfig();
-    const baseURI = `${sp.api.excel.update.fgBaseURI}`;
+    const baseURI = `${sp.api.file.get.fgBaseURI}`;
     const rootFolder = baseURI.split('/').pop();
     const options = await getAuthorizedRequestOption({ method: 'GET' });
     const promoteIgnoreList = appConfig.getPromoteIgnorePaths();

--- a/actions/sharepoint.js
+++ b/actions/sharepoint.js
@@ -80,6 +80,24 @@ async function getDriveRoot(accessToken) {
     return null;
 }
 
+async function getExcelTable(excelPath, tableName) {
+    const { sp } = await getConfig();
+    const options = await getAuthorizedRequestOption();
+    const res = await fetchWithRetry(
+        `${sp.api.file.get.baseURI}${excelPath}:/workbook/tables/${tableName}/rows`,
+        options,
+    );
+    if (res.ok) {
+        const tableJson = await res.json();
+        // tableJson is {value: [<rows>{ index: 0, values: [[<all cols>]] }]}
+        return !tableJson?.value ? [] :
+            tableJson.value
+                .filter((e) => e.values?.find((rw) => rw.find((col) => col)))
+                .map((e) => e.values);
+    }
+    throw new Error(`Failed to getExcelTable from ${excelPath} table ${tableName} : ${JSON.stringify(res)}.`);
+}
+
 async function getFileData(filePath, isFloodgate) {
     const { sp } = await getConfig();
     const options = await getAuthorizedRequestOption();
@@ -413,6 +431,8 @@ function logHeaders(response) {
 
 module.exports = {
     getAuthorizedRequestOption,
+    getDriveRoot,
+    getExcelTable,
     getFilesData,
     getFile,
     getFileUsingDownloadUrl,
@@ -424,5 +444,4 @@ module.exports = {
     getFolderFromPath,
     getFileNameFromPath,
     bulkCreateFolders,
-    getDriveRoot,
 };

--- a/actions/sharepoint.js
+++ b/actions/sharepoint.js
@@ -68,10 +68,10 @@ async function executeGQL(url, opts) {
     return res.json();
 }
 
-async function getItemUri(uri, path) {
+async function getItemId(uri, path) {
     const key = `~${uri}~${path}~`;
     itemIdMap[key] = itemIdMap[key] || await executeGQL(`${uri}${path}?$select=id`);
-    return uri && itemIdMap[key]?.id && `${uri.replace(/\/root:[^:]*$/, '')}/items/${itemIdMap[key].id}`;
+    return itemIdMap[key]?.id;
 }
 
 async function getDriveRoot(accessToken) {
@@ -352,9 +352,9 @@ async function saveFile(file, dest, isFloodgate) {
 
 async function getExcelTable(excelPath, tableName) {
     const { sp } = await getConfig();
-    const itemUri = await getItemUri(sp.api.file.get.baseURI, excelPath);
-    if (itemUri) {
-        const tableJson = await executeGQL(`${itemUri}/workbook/tables/${tableName}/rows`);
+    const itemId = await getItemId(sp.api.file.get.baseURI, excelPath);
+    if (itemId) {
+        const tableJson = await executeGQL(`${sp.api.excel.get.baseItemsURI}/${itemId}/workbook/tables/${tableName}/rows`);
         return !tableJson?.value ? [] :
             tableJson.value
                 .filter((e) => e.values?.find((rw) => rw.find((col) => col)))
@@ -365,9 +365,9 @@ async function getExcelTable(excelPath, tableName) {
 
 async function updateExcelTable(excelPath, tableName, values) {
     const { sp } = await getConfig();
-    const itemUri = await getItemUri(sp.api.file.get.baseURI, excelPath);
-    if (itemUri) {
-        return executeGQL(`${itemUri}/workbook/tables/${tableName}/rows`, {
+    const itemId = await getItemId(sp.api.file.get.baseURI, excelPath);
+    if (itemId) {
+        return executeGQL(`${sp.api.excel.update.baseItemsURI}/${itemId}/workbook/tables/${tableName}/rows`, {
             body: JSON.stringify({ values }),
             method: sp.api.excel.update.method,
         });

--- a/actions/sharepoint.js
+++ b/actions/sharepoint.js
@@ -95,7 +95,7 @@ async function getExcelTable(excelPath, tableName) {
                 .filter((e) => e.values?.find((rw) => rw.find((col) => col)))
                 .map((e) => e.values);
     }
-    throw new Error(`Failed to getExcelTable from ${excelPath} table ${tableName} : ${JSON.stringify(res)}.`);
+    throw new Error(`Failed to getExcelTable from ${excelPath} table ${tableName}`);
 }
 
 async function getFileData(filePath, isFloodgate) {

--- a/actions/sharepoint.js
+++ b/actions/sharepoint.js
@@ -32,6 +32,7 @@ const TOO_MANY_REQUESTS = '429';
 // Added for debugging rate limit headers
 const LOG_RESP_HEADER = false;
 let nextCallAfter = 0;
+const itemIdMap = {};
 
 // eslint-disable-next-line default-param-last
 async function getAuthorizedRequestOption({ body = null, json = true, method = 'GET' } = {}) {
@@ -58,6 +59,21 @@ async function getAuthorizedRequestOption({ body = null, json = true, method = '
     return options;
 }
 
+async function executeGQL(url, opts) {
+    const options = await getAuthorizedRequestOption(opts);
+    const res = await fetchWithRetry(url, options);
+    if (!res.ok) {
+        throw new Error(`Failed to execute ${url}`);
+    }
+    return res.json();
+}
+
+async function getItemUri(uri, path) {
+    const key = `~${uri}~${path}~`;
+    itemIdMap[key] = itemIdMap[key] || await executeGQL(`${uri}${path}?$select=id`);
+    return uri && itemIdMap[key]?.id && `${uri.replace(/\/root:[^:]*$/, '')}/items/${itemIdMap[key].id}`;
+}
+
 async function getDriveRoot(accessToken) {
     const logger = getAioLogger();
     try {
@@ -78,24 +94,6 @@ async function getDriveRoot(accessToken) {
         logger.info(JSON.stringify(error));
     }
     return null;
-}
-
-async function getExcelTable(excelPath, tableName) {
-    const { sp } = await getConfig();
-    const options = await getAuthorizedRequestOption();
-    const res = await fetchWithRetry(
-        `${sp.api.file.get.baseURI}${excelPath}:/workbook/tables/${tableName}/rows`,
-        options,
-    );
-    if (res.ok) {
-        const tableJson = await res.json();
-        // tableJson is {value: [<rows>{ index: 0, values: [[<all cols>]] }]}
-        return !tableJson?.value ? [] :
-            tableJson.value
-                .filter((e) => e.values?.find((rw) => rw.find((col) => col)))
-                .map((e) => e.values);
-    }
-    throw new Error(`Failed to getExcelTable from ${excelPath} table ${tableName}`);
 }
 
 async function getFileData(filePath, isFloodgate) {
@@ -352,22 +350,29 @@ async function saveFile(file, dest, isFloodgate) {
     return { success: false, path: dest };
 }
 
+async function getExcelTable(excelPath, tableName) {
+    const { sp } = await getConfig();
+    const itemUri = await getItemUri(sp.api.file.get.baseURI, excelPath);
+    if (itemUri) {
+        const tableJson = await executeGQL(`${itemUri}/workbook/tables/${tableName}/rows`);
+        return !tableJson?.value ? [] :
+            tableJson.value
+                .filter((e) => e.values?.find((rw) => rw.find((col) => col)))
+                .map((e) => e.values);
+    }
+    return [];
+}
+
 async function updateExcelTable(excelPath, tableName, values) {
     const { sp } = await getConfig();
-
-    const options = await getAuthorizedRequestOption({
-        body: JSON.stringify({ values }),
-        method: sp.api.excel.update.method,
-    });
-
-    const res = await fetch(
-        `${sp.api.excel.update.baseURI}${excelPath}:/workbook/tables/${tableName}/rows/add`,
-        options,
-    );
-    if (res.ok) {
-        return res.json();
+    const itemUri = await getItemUri(sp.api.file.get.baseURI, excelPath);
+    if (itemUri) {
+        return executeGQL(`${itemUri}/workbook/tables/${tableName}/rows`, {
+            body: JSON.stringify({ values }),
+            method: sp.api.excel.update.method,
+        });
     }
-    throw new Error(`Failed to update excel sheet ${excelPath} table ${tableName}.`);
+    return {};
 }
 
 // fetch-with-retry added to check for Sharepoint RateLimit headers and 429 errors and to handle them accordingly.
@@ -431,6 +436,7 @@ function logHeaders(response) {
 
 module.exports = {
     getAuthorizedRequestOption,
+    executeGQL,
     getDriveRoot,
     getExcelTable,
     getFilesData,


### PR DESCRIPTION
For supporting the other drives (e.g CC) root url was updated to include the driveId. It was observed that API used too update XLS table was not working. The uri pattern is <site uri>/drive/<driveId>/root:<path>:/workbook/.. which did not work. An alternate url pattern with <site uri>/drive/<driveId>/items/<itemId>/workbook/.. appears to work.
    
This also works for default drive  i.e. <site uri>/drive/items/<itemId>/workbook/..

Resolves: MWPW-134760, MWPW-134759
