### PR TITLE
MWPW-134726: Adobe IO: Delete Floodgate Content

### DIFF
--- a/actions/appConfig.js
+++ b/actions/appConfig.js
@@ -50,6 +50,7 @@ class AppConfig {
         this.configMap.groupCheckUrl = params.groupCheckUrl;
         this.configMap.fgUserGroups = this.getJsonFromStr(params.fgUserGroups, []);
         this.configMap.fgAdminGroups = this.getJsonFromStr(params.fgAdminGroups, []);
+        this.configMap.fgDirPattern = params.fgDirPattern;
         this.extractPrivateKey();
     }
 

--- a/actions/delete/delete.js
+++ b/actions/delete/delete.js
@@ -35,7 +35,7 @@ async function main(args) {
     appConfig.setAppConfig(args);
     const projectPath = `${rootFolder}${projectExcelPath}`;
     const userDetails = sharepointAuth.getUserDetails(spToken);
-    const fgStatus = new FgStatus({ action: DELETE_ACTION, statusKey: projectPath, userDetails });
+    const fgStatus = new FgStatus({ action: DELETE_ACTION, statusKey: '${DELETE_ACTION}~${projectPath}', userDetails });
     logger.info(`Delete action for ${projectPath} triggered by ${JSON.stringify(userDetails)}`);
     try {
         if (!rootFolder || !projectExcelPath) {

--- a/actions/delete/delete.js
+++ b/actions/delete/delete.js
@@ -1,0 +1,119 @@
+/* ************************************************************************
+* ADOBE CONFIDENTIAL
+* ___________________
+*
+* Copyright 2023 Adobe
+* All Rights Reserved.
+*
+* NOTICE: All information contained herein is, and remains
+* the property of Adobe and its suppliers, if any. The intellectual
+* and technical concepts contained herein are proprietary to Adobe
+* and its suppliers and are protected by all applicable intellectual
+* property laws, including trade secret and copyright laws.
+* Dissemination of this information or reproduction of this material
+* is strictly forbidden unless prior written permission is obtained
+* from Adobe.
+************************************************************************* */
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+const openwhisk = require('openwhisk');
+const {
+    getAioLogger, actInProgress, DELETE_ACTION
+} = require('../utils');
+const appConfig = require('../appConfig');
+const { isAuthorizedUser } = require('../sharepoint');
+const sharepointAuth = require('../sharepointAuth');
+const FgStatus = require('../fgStatus');
+
+// This returns the activation ID of the action that it called
+async function main(args) {
+    const logger = getAioLogger();
+    let payload;
+    const {
+        spToken, adminPageUri, projectExcelPath, rootFolder
+    } = args;
+    appConfig.setAppConfig(args);
+    const projectPath = `${rootFolder}${projectExcelPath}`;
+    const userDetails = sharepointAuth.getUserDetails(spToken);
+    const fgStatus = new FgStatus({ action: DELETE_ACTION, statusKey: projectPath, userDetails });
+    logger.info(`Delete action for ${projectPath} triggered by ${JSON.stringify(userDetails)}`);
+    try {
+        if (!rootFolder || !projectExcelPath) {
+            payload = 'Could not determine the project path. Try reloading the page and trigger the action again.';
+            logger.error(payload);
+        } else if (!adminPageUri) {
+            payload = 'Required data is not available to proceed with Delete action.';
+            logger.error(payload);
+            payload = await fgStatus.updateStatusToStateLib({
+                status: FgStatus.PROJECT_STATUS.FAILED,
+                statusMessage: payload
+            });
+        } else {
+            const ow = openwhisk();
+            const storeValue = await fgStatus.getStatusFromStateLib();
+            const actId = storeValue?.action?.activationId;
+            const svStatus = storeValue?.action?.status;
+            const accountDtls = await isAuthorizedUser(spToken);
+            if (!accountDtls) {
+                payload = 'Could not determine the user.';
+                logger.error(payload);
+            } else if (!appConfig.getSkipInProgressCheck() &&
+                await actInProgress(ow, actId, FgStatus.isInProgress(svStatus))) {
+                payload = `A delete action with activationid: ${storeValue?.action?.activationId} is already in progress. 
+                Not triggering this action. And the previous action can be retrieved by refreshing the console page`;
+                storeValue.action.status = FgStatus.PROJECT_STATUS.FAILED;
+                storeValue.action.message = payload;
+                payload = storeValue;
+            } else {
+                payload = await fgStatus.updateStatusToStateLib({
+                    status: FgStatus.PROJECT_STATUS.STARTED,
+                    statusMessage: 'Triggering delete action'
+                });
+                return ow.actions.invoke({
+                    name: 'milo-fg/delete-worker',
+                    blocking: false, // this is the flag that instructs to execute the worker asynchronous
+                    result: false,
+                    params: args
+                }).then(async (result) => {
+                    logger.info(result);
+                    //  attaching activation id to the status
+                    payload = await fgStatus.updateStatusToStateLib({
+                        status: FgStatus.PROJECT_STATUS.IN_PROGRESS,
+                        activationId: result.activationId
+                    });
+                    return {
+                        code: 200,
+                        payload
+                    };
+                }).catch(async (err) => {
+                    payload = await fgStatus.updateStatusToStateLib({
+                        status: FgStatus.PROJECT_STATUS.FAILED,
+                        statusMessage: `Failed to invoke actions ${err.message}`
+                    });
+                    logger.error('Failed to invoke actions', err);
+                    return {
+                        code: 500,
+                        payload
+                    };
+                });
+            }
+            return {
+                code: 500,
+                payload
+            };
+        }
+    } catch (err) {
+        payload = fgStatus.updateStatusToStateLib({
+            status: FgStatus.PROJECT_STATUS.FAILED,
+            statusMessage: `Failed to invoke actions ${err.message}`
+        });
+        logger.error(err);
+    }
+
+    return {
+        code: 500,
+        payload,
+    };
+}
+
+exports.main = main;

--- a/actions/delete/delete.js
+++ b/actions/delete/delete.js
@@ -21,9 +21,9 @@ const {
     getAioLogger, actInProgress, DELETE_ACTION
 } = require('../utils');
 const appConfig = require('../appConfig');
-const { isAuthorizedUser } = require('../sharepoint');
 const sharepointAuth = require('../sharepointAuth');
 const FgStatus = require('../fgStatus');
+const FgUser = require('../fgUser');
 
 // This returns the activation ID of the action that it called
 async function main(args) {
@@ -35,7 +35,7 @@ async function main(args) {
     appConfig.setAppConfig(args);
     const projectPath = `${rootFolder}${projectExcelPath}`;
     const userDetails = sharepointAuth.getUserDetails(spToken);
-    const fgStatus = new FgStatus({ action: DELETE_ACTION, statusKey: '${DELETE_ACTION}~${projectPath}', userDetails });
+    const fgStatus = new FgStatus({ action: DELETE_ACTION, statusKey: `${DELETE_ACTION}~${projectPath}`, userDetails });
     logger.info(`Delete action for ${projectPath} triggered by ${JSON.stringify(userDetails)}`);
     try {
         if (!rootFolder || !projectExcelPath) {
@@ -53,8 +53,8 @@ async function main(args) {
             const storeValue = await fgStatus.getStatusFromStateLib();
             const actId = storeValue?.action?.activationId;
             const svStatus = storeValue?.action?.status;
-            const accountDtls = await isAuthorizedUser(spToken);
-            if (!accountDtls) {
+            const fgUser = new FgUser({ at: args.spToken });
+            if (!await fgUser.isUser()) {
                 payload = 'Could not determine the user.';
                 logger.error(payload);
             } else if (!appConfig.getSkipInProgressCheck() &&

--- a/actions/delete/worker.js
+++ b/actions/delete/worker.js
@@ -32,7 +32,7 @@ async function main(params) {
     } = params;
     appConfig.setAppConfig(params);
     const projectPath = `${rootFolder}${projectExcelPath}`;
-    const fgStatus = new FgStatus({ action: DELETE_ACTION, statusKey: `${DELETE_ACTION}~${projectPath}` });
+    const fgStatus = new FgStatus({ action: DELETE_ACTION, statusKey: `${DELETE_ACTION}~${fgRootFolder}` });
     try {
         if (!rootFolder || !projectExcelPath) {
             payload = 'Could not determine the project path. Try reloading the page and trigger the action again.';

--- a/actions/delete/worker.js
+++ b/actions/delete/worker.js
@@ -1,0 +1,72 @@
+/* ************************************************************************
+* ADOBE CONFIDENTIAL
+* ___________________
+*
+* Copyright 2023 Adobe
+* All Rights Reserved.
+*
+* NOTICE: All information contained herein is, and remains
+* the property of Adobe and its suppliers, if any. The intellectual
+* and technical concepts contained herein are proprietary to Adobe
+* and its suppliers and are protected by all applicable intellectual
+* property laws, including trade secret and copyright laws.
+* Dissemination of this information or reproduction of this material
+* is strictly forbidden unless prior written permission is obtained
+* from Adobe.
+************************************************************************* */
+
+const { deleteAll } = require('../sharepoint');
+const {
+    getAioLogger, logMemUsage, DELETE_ACTION
+} = require('../utils');
+const appConfig = require('../appConfig');
+const urlInfo = require('../urlInfo');
+const FgStatus = require('../fgStatus');
+
+async function main(params) {
+    const logger = getAioLogger();
+    logMemUsage();
+    let payload;
+    const {
+        adminPageUri, projectExcelPath, rootFolder,
+    } = params;
+    appConfig.setAppConfig(params);
+    const projectPath = `${rootFolder}${projectExcelPath}`;
+    const fgStatus = new FgStatus({ action: DELETE_ACTION, statusKey: projectPath });
+    try {
+        if (!rootFolder || !projectExcelPath) {
+            payload = 'Could not determine the project path. Try reloading the page and trigger the action again.';
+            logger.error(payload);
+        } else if (!adminPageUri) {
+            payload = 'Required data is not available to proceed with Delete action.';
+            fgStatus.updateStatusToStateLib({
+                status: FgStatus.PROJECT_STATUS.FAILED,
+                statusMessage: payload
+            });
+            logger.error(payload);
+        } else {
+            urlInfo.setUrlInfo(adminPageUri);
+            payload = 'Started deleting content';
+            logger.info(payload);
+            fgStatus.updateStatusToStateLib({
+                status: FgStatus.PROJECT_STATUS.IN_PROGRESS,
+                statusMessage: payload
+            });
+
+            payload = await deleteAll(projectExcelPath, fgStatus);
+        }
+    } catch (err) {
+        fgStatus.updateStatusToStateLib({
+            status: FgStatus.PROJECT_STATUS.COMPLETED_WITH_ERROR,
+            statusMessage: err.message
+        });
+        logger.error(err);
+        payload = err;
+    }
+    logMemUsage();
+    return {
+        body: payload,
+    };
+}
+
+exports.main = main;

--- a/actions/delete/worker.js
+++ b/actions/delete/worker.js
@@ -32,7 +32,7 @@ async function main(params) {
     } = params;
     appConfig.setAppConfig(params);
     const projectPath = `${rootFolder}${projectExcelPath}`;
-    const fgStatus = new FgStatus({ action: DELETE_ACTION, statusKey: projectPath });
+    const fgStatus = new FgStatus({ action: DELETE_ACTION, statusKey: '${DELETE_ACTION}~${projectPath}' });
     try {
         if (!rootFolder || !projectExcelPath) {
             payload = 'Could not determine the project path. Try reloading the page and trigger the action again.';

--- a/actions/delete/worker.js
+++ b/actions/delete/worker.js
@@ -15,7 +15,7 @@
 * from Adobe.
 ************************************************************************* */
 
-const { deleteAll } = require('../sharepoint');
+const { deleteFloodgateDir, updateExcelTable } = require('../sharepoint');
 const {
     getAioLogger, logMemUsage, DELETE_ACTION
 } = require('../utils');
@@ -32,7 +32,7 @@ async function main(params) {
     } = params;
     appConfig.setAppConfig(params);
     const projectPath = `${rootFolder}${projectExcelPath}`;
-    const fgStatus = new FgStatus({ action: DELETE_ACTION, statusKey: '${DELETE_ACTION}~${projectPath}' });
+    const fgStatus = new FgStatus({ action: DELETE_ACTION, statusKey: `${DELETE_ACTION}~${projectPath}` });
     try {
         if (!rootFolder || !projectExcelPath) {
             payload = 'Could not determine the project path. Try reloading the page and trigger the action again.';
@@ -53,7 +53,19 @@ async function main(params) {
                 statusMessage: payload
             });
 
-            payload = await deleteAll(projectExcelPath, fgStatus);
+            const { fgRootFolder } = appConfig.getPayload();
+            const deleteStatus = await deleteFloodgateDir(fgRootFolder);
+            payload = deleteStatus === false ?
+                'Error occurred when deleting content. Check project excel sheet for additional information.' :
+                'Delete action was completed';
+            await fgStatus.updateStatusToStateLib({
+                status: deleteStatus === false ? FgStatus.PROJECT_STATUS.COMPLETED_WITH_ERROR : FgStatus.PROJECT_STATUS.COMPLETED,
+                statusMessage: payload
+            });
+            const { startTime: startDelete, endTime: endDelete } = fgStatus.getStartEndTime();
+            const excelValues = [['DELETE', startDelete, endDelete, payload]];
+            await updateExcelTable(projectExcelPath, 'DELETE_STATUS', excelValues);
+            logger.info('Project excel file updated with delete status.');
         }
     } catch (err) {
         fgStatus.updateStatusToStateLib({

--- a/actions/sharepoint.js
+++ b/actions/sharepoint.js
@@ -374,7 +374,7 @@ async function deleteFloodgateDir(fgRootFolder) {
     logger.info(fgRegExp);
     if (fgRegExp.test(baseURI)) {
         logger.info(`Deleting the folder ${baseURI} `);
-        const temp = '/drafts/nsivakum/trial';
+        const temp = '/temp';
         const finalBaserURI = baseURI + temp;
         try {
             const { sp } = await getConfig();

--- a/actions/sharepoint.js
+++ b/actions/sharepoint.js
@@ -21,6 +21,7 @@ const { getConfig } = require('./config');
 const { getAioLogger } = require('./utils');
 const appConfig = require('./appConfig');
 const sharepointAuth = require('./sharepointAuth');
+const FgStatus = require('./fgStatus');
 
 const SP_CONN_ERR_LST = ['ETIMEDOUT', 'ECONNRESET'];
 const APP_USER_AGENT = 'ISV|Adobe|MiloFloodgate/0.1.0';
@@ -363,6 +364,59 @@ async function getExcelTable(excelPath, tableName) {
     return [];
 }
 
+async function deleteAll(projectExcelPath, fgStatus) {
+    const logger = getAioLogger();
+    logger.info('Deleting content started.');
+    const deleteStatuses = [];
+    const { sp } = await getConfig();
+    const fgFolders = [''];
+    const baseURI = sp.api.directory.create.fgBaseURI;
+    const finalBaserURI = baseURI + '/drafts/nsivakum/trial';
+    const options = await getAuthorizedRequestOption({ method: 'GET' });
+    const uri = `${finalBaserURI}${fgFolders.shift()}:/children`;
+    const res = await fetchWithRetry(uri, options);
+    if (res.ok) {
+        const json = await res.json();
+        const files = json.value;
+        for (let i = 0; i < files.length; i += 1) {
+            const status = await deleteItemInProject('/drafts/nsivakum/trial/' + files[i].name);
+            deleteStatuses.push(status);
+        }
+    }
+    const failedDeletes = deleteStatuses.filter((status) => !status.success)
+        .map((status) => status.path || 'Path Info Not available');
+
+    const fgErrors = failedDeletes.length > 0;
+    const payload = fgErrors ?
+        'Error occurred when deleting content. Check project excel sheet for additional information.' :
+        'Delete action was completed';
+    await fgStatus.updateStatusToStateLib({
+        status: fgErrors ? FgStatus.PROJECT_STATUS.COMPLETED_WITH_ERROR : FgStatus.PROJECT_STATUS.COMPLETED,
+        statusMessage: payload
+    });
+    const { startTime: startDelete, endTime: endDelete } = fgStatus.getStartEndTime();
+    const excelValues = [['DELETE', startDelete, endDelete, failedDeletes.join('\n')]];
+    await updateExcelTable(projectExcelPath, 'DELETE_STATUS', excelValues);
+    logger.info('Project excel file updated with delete status.');
+    return payload;
+}
+
+async function deleteItemInProject(filePath) {
+    const status = { success: false };
+    let deleteSuccess = true;
+    try {
+        const { sp } = await getConfig();
+        const baseURI = sp.api.file.get.fgBaseURI;
+        await deleteFile(sp, `${baseURI}${filePath}`);
+        deleteSuccess = true;
+    } catch (error) {
+        console.log(`Error occurred when trying to delete files of main content tree ${error.message}`);
+    }
+    status.success = deleteSuccess;
+    status.path = filePath;
+    return status;
+}
+
 async function updateExcelTable(excelPath, tableName, values) {
     const { sp } = await getConfig();
     const itemId = await getItemId(sp.api.file.get.baseURI, excelPath);
@@ -450,4 +504,5 @@ module.exports = {
     getFolderFromPath,
     getFileNameFromPath,
     bulkCreateFolders,
+    deleteAll,
 };

--- a/actions/utils.js
+++ b/actions/utils.js
@@ -23,6 +23,7 @@ const urlInfo = require('./urlInfo');
 const COPY_ACTION = 'copyAction';
 const PROMOTE_ACTION = 'promoteAction';
 const PROMOTE_BATCH = 'promoteBatch';
+const DELETE_ACTION = 'deleteAction';
 const PREVIEW = 'preview';
 const PUBLISH = 'live';
 
@@ -136,6 +137,7 @@ module.exports = {
     COPY_ACTION,
     PROMOTE_ACTION,
     PROMOTE_BATCH,
+    DELETE_ACTION,
     PREVIEW,
     PUBLISH,
     logMemUsage,

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -37,6 +37,18 @@ application:
             limits:
               timeout: 3600000
               memorySize: 2048
+          delete:
+            function: actions/delete/delete.js
+            web: 'yes'
+            runtime: nodejs:16
+            inputs:
+              LOG_LEVEL: debug
+          delete-worker:
+            function: actions/delete/worker.js
+            web: 'no'
+            runtime: nodejs:16
+            inputs:
+              LOG_LEVEL: debug
           promote:
             function: actions/promote/promote.js
             web: 'yes'

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -21,6 +21,7 @@ application:
           groupCheckUrl: $GROUP_CHECK_URL
           fgUserGroups: $FG_USER_GROUPS
           fgAdminGroups: $FG_ADMIN_GROUPS
+          fgDirPattern: $FG_DIR_PATTERN
         actions:
           copy:
             function: actions/copy/copy.js


### PR DESCRIPTION
When the user clicks on the "Delete" button on the FG admin page:

- Delete everything under "/<app>-pink" root FG project folder
- Update the status of the Delete in the XLSX file
- Returns the deleted status in the payload

Link to the ticket: https://jira.corp.adobe.com/browse/MWPW-134726 
Note: Currently, the path to the folder that is to be deleted is set to milo-pink/drafts/nsivakum/trial in order to avoid a mistaken deletion of the milo-pink folder.
The env file needs to be updated with FG_DIR_PATTERN=-(pink)$ . this is done to accommodate additional floodgate folders that might be created (like purple, blue, etc)