### PR TITLE
MWPW-134760 Fetch promote files for restricted sites (e.g CC)

### DIFF
--- a/actions/promote/createBatch.js
+++ b/actions/promote/createBatch.js
@@ -156,8 +156,6 @@ async function findAndBatchFGFiles(
                     logger.info(`Ignored from promote: ${itemPath}`);
                 }
             }
-        } else {
-            logger.error(`Could not fetch tree files for URL ${uri}`);
         }
     }
 }

--- a/actions/promote/createBatch.js
+++ b/actions/promote/createBatch.js
@@ -107,17 +107,14 @@ async function main(params) {
  */
 async function createBatch(batchManager) {
     const { sp } = await getConfig();
-    const baseURI = `${sp.api.file.get.fgBaseURI}`;
-    const rootFolder = baseURI.split('/').pop();
     const options = await getAuthorizedRequestOption({ method: 'GET' });
     const promoteIgnoreList = appConfig.getPromoteIgnorePaths();
     logger.info(`Promote ignore list: ${promoteIgnoreList}`);
 
     // Temporarily restricting the iteration for promote to under /drafts folder only
     return findAndBatchFGFiles({
-        baseURI,
+        baseURI: sp.api.file.get.fgBaseURI,
         options,
-        rootFolder,
         fgFolders: ['/drafts'],
         promoteIgnoreList,
         downloadBaseURI: sp.api.file.download.baseURI
@@ -129,9 +126,11 @@ async function createBatch(batchManager) {
  */
 async function findAndBatchFGFiles(
     {
-        baseURI, options, rootFolder, fgFolders, promoteIgnoreList, downloadBaseURI
+        baseURI, options, fgFolders, promoteIgnoreList, downloadBaseURI
     }, batchManager
 ) {
+    const fgRoot = baseURI.split(':').pop();
+    const pPathRegExp = new RegExp(`.*:${fgRoot}`);
     while (fgFolders.length !== 0) {
         const uri = `${baseURI}${fgFolders.shift()}:/children?$top=${MAX_CHILDREN}`;
         // eslint-disable-next-line no-await-in-loop
@@ -143,7 +142,7 @@ async function findAndBatchFGFiles(
             const driveItems = json.value;
             for (let di = 0; di < driveItems?.length; di += 1) {
                 const item = driveItems[di];
-                const itemPath = `${item.parentReference.path.replace(`/drive/root:/${rootFolder}`, '')}/${item.name}`;
+                const itemPath = `${item.parentReference.path.replace(pPathRegExp, '')}/${item.name}`;
                 if (!promoteIgnoreList?.includes(itemPath)) {
                     if (item.folder) {
                         // it is a folder
@@ -157,6 +156,8 @@ async function findAndBatchFGFiles(
                     logger.info(`Ignored from promote: ${itemPath}`);
                 }
             }
+        } else {
+            logger.error(`Could not fetch tree files for URL ${uri}`);
         }
     }
 }


### PR DESCRIPTION
Find files in promote action filters out the `/drive/root:...` for extracting parent folder path from a list response and this does not work with restricted sites as URL instead contains `/drives/<id>/root:...`
Example-
`https://graph.microsoft.com/v1.0/sites/adobe.sharepoint.com,d....2b6161a051b/drives/b....OQ/root:/www-pink/drafts/test`
extracted parent path needed is `drafts/test`

Changes done to extract parent path from either path. It support both `/drive/root:...` and `/drives/<id>/root:...` paths.