### PR TITLE
MWPW-134760 Copy/Promote on restricted site (eg: CC)

### DIFF
--- a/actions/appConfig.js
+++ b/actions/appConfig.js
@@ -50,6 +50,9 @@ class AppConfig {
         this.configMap.groupCheckUrl = params.groupCheckUrl;
         this.configMap.fgUserGroups = this.getJsonFromStr(params.fgUserGroups, []);
         this.configMap.fgAdminGroups = this.getJsonFromStr(params.fgAdminGroups, []);
+        this.configMap.siteRootPathRex = this.siteRootPathRex || '.*/sites(/.*)<';
+        this.configMap.siteRootPath = this.getSiteRootPath(params.shareUrl);
+        this.configMap.siteFgRootPath = this.getSiteRootPath(params.fgShareUrl);
         this.extractPrivateKey();
     }
 
@@ -129,6 +132,14 @@ class AppConfig {
 
     getNumBulkReq() {
         return this.configMap.numBulkReq;
+    }
+
+    getSiteRootPath(shareUrl) {
+        try {
+            return shareUrl.match(new RegExp(this.configMap.siteRootPathRex))[1];
+        } catch (err) {
+            return '/';
+        }
     }
 }
 

--- a/actions/config.js
+++ b/actions/config.js
@@ -28,7 +28,6 @@ function getSharepointConfig(applicationConfig) {
     const baseURI = `${applicationConfig.fgSite}${drive}/root:${applicationConfig.payload.rootFolder}`;
     const fgBaseURI = `${applicationConfig.fgSite}${drive}/root:${applicationConfig.payload.fgRootFolder}`;
     const baseItemsURI = `${applicationConfig.fgSite}${drive}/items`;
-    const fgBaseItemsURI = `${applicationConfig.fgSite}${drive}/items`;
     return {
         ...applicationConfig,
         clientApp: {
@@ -83,10 +82,9 @@ function getSharepointConfig(applicationConfig) {
                 },
             },
             excel: {
-                get: { baseItemsURI, fgBaseItemsURI },
+                get: { baseItemsURI },
                 update: {
                     baseItemsURI,
-                    fgBaseItemsURI,
                     method: 'POST',
                 },
             },

--- a/actions/copy/copy.js
+++ b/actions/copy/copy.js
@@ -33,10 +33,9 @@ async function main(args) {
         spToken, adminPageUri, projectExcelPath, rootFolder
     } = args;
     appConfig.setAppConfig(args);
-    const projectPath = `${rootFolder}${projectExcelPath}`;
     const userDetails = sharepointAuth.getUserDetails(spToken);
-    const fgStatus = new FgStatus({ action: COPY_ACTION, statusKey: projectPath, userDetails });
-    logger.info(`Copy action for ${projectPath} triggered by ${JSON.stringify(userDetails)}`);
+    const fgStatus = new FgStatus({ action: COPY_ACTION, userDetails });
+    logger.info(`Copy action for ${fgStatus.getStoreKey()} triggered by ${JSON.stringify(userDetails)}`);
     try {
         if (!rootFolder || !projectExcelPath) {
             payload = 'Could not determine the project path. Try reloading the page and trigger the action again.';

--- a/actions/copy/worker.js
+++ b/actions/copy/worker.js
@@ -39,8 +39,7 @@ async function main(params) {
         adminPageUri, projectExcelPath, rootFolder
     } = params;
     appConfig.setAppConfig(params);
-    const projectPath = `${rootFolder}${projectExcelPath}`;
-    const fgStatus = new FgStatus({ action: COPY_ACTION, statusKey: projectPath });
+    const fgStatus = new FgStatus({ action: COPY_ACTION });
     try {
         if (!rootFolder || !projectExcelPath) {
             payload = 'Could not determine the project path. Try reloading the page and trigger the action again.';

--- a/actions/delete/delete.js
+++ b/actions/delete/delete.js
@@ -35,7 +35,7 @@ async function main(args) {
     appConfig.setAppConfig(args);
     const projectPath = `${rootFolder}${projectExcelPath}`;
     const userDetails = sharepointAuth.getUserDetails(spToken);
-    const fgStatus = new FgStatus({ action: DELETE_ACTION, statusKey: `${DELETE_ACTION}~${projectPath}`, userDetails });
+    const fgStatus = new FgStatus({ action: DELETE_ACTION, userDetails });
     logger.info(`Delete action for ${projectPath} triggered by ${JSON.stringify(userDetails)}`);
     try {
         if (!rootFolder || !projectExcelPath) {

--- a/actions/delete/worker.js
+++ b/actions/delete/worker.js
@@ -31,9 +31,8 @@ async function main(params) {
         adminPageUri, projectExcelPath, rootFolder,
     } = params;
     appConfig.setAppConfig(params);
-    const projectPath = `${rootFolder}${projectExcelPath}`;
     const { fgRootFolder } = appConfig.getPayload();
-    const fgStatus = new FgStatus({ action: DELETE_ACTION, statusKey: `${DELETE_ACTION}~${fgRootFolder}` });
+    const fgStatus = new FgStatus({ action: DELETE_ACTION });
     try {
         if (!rootFolder || !projectExcelPath) {
             payload = 'Could not determine the project path. Try reloading the page and trigger the action again.';

--- a/actions/delete/worker.js
+++ b/actions/delete/worker.js
@@ -53,7 +53,7 @@ async function main(params) {
                 statusMessage: payload
             });
 
-            const deleteStatus = await deleteFloodgateDir(fgRootFolder);
+            const deleteStatus = await deleteFloodgateDir();
             payload = deleteStatus === false ?
                 'Error occurred when deleting content. Check project excel sheet for additional information.' :
                 'Delete action was completed';

--- a/actions/fgStatus.js
+++ b/actions/fgStatus.js
@@ -62,16 +62,24 @@ class FgStatus {
      * @param {*} options statusKey is the key to be used to store
      * and actionType is the type of FG Action like copy or promote
      */
-    constructor({ action, statusKey, keySuffix, userDetails }) {
+    constructor({
+        action,
+        statusKey,
+        keySuffix,
+        userDetails
+    }) {
         this.lastTriggeredBy = userDetails?.oid;
         this.action = action || '';
-        this.storeKey = statusKey || `${this.getActionRootPath()}${keySuffix || ''}` || FG_KEY;
+        this.storeKey = statusKey || this.generateStoreKey(keySuffix) || FG_KEY;
         this.logger = getAioLogger();
     }
 
-    getActionRootPath() {
+    generateStoreKey(keySuffix) {
         const { siteRootPath, siteFgRootPath } = appConfig.getConfig();
-        return this.action === COPY_ACTION ? siteRootPath : siteFgRootPath;
+        const { projectExcelPath } = appConfig.getPayload();
+        let resp = this.action === COPY_ACTION ? `${siteRootPath || ''}${projectExcelPath || ''}` : siteFgRootPath;
+        resp += keySuffix || '';
+        return resp;
     }
 
     getStoreKey() {

--- a/actions/fgStatus.js
+++ b/actions/fgStatus.js
@@ -17,7 +17,7 @@
 
 const stateLib = require('@adobe/aio-lib-state');
 const crypto = require('crypto');
-const { getAioLogger, COPY_ACTION } = require('./utils');
+const { getAioLogger, COPY_ACTION, DELETE_ACTION } = require('./utils');
 const appConfig = require('./appConfig');
 
 const FG_KEY = 'FLOODGATE';
@@ -77,7 +77,18 @@ class FgStatus {
     generateStoreKey(keySuffix) {
         const { siteRootPath, siteFgRootPath } = appConfig.getConfig();
         const { projectExcelPath } = appConfig.getPayload();
-        let resp = this.action === COPY_ACTION ? `${siteRootPath || ''}${projectExcelPath || ''}` : siteFgRootPath;
+        let resp = '';
+
+        switch (this.action) {
+            case COPY_ACTION:
+                resp = `${siteRootPath || ''}${projectExcelPath || ''}`;
+                break;
+            case DELETE_ACTION:
+                resp = `${DELETE_ACTION}${siteFgRootPath}`;
+                break;
+            default:
+                resp = siteFgRootPath;
+        }
         resp += keySuffix || '';
         return resp;
     }

--- a/actions/fgStatus.js
+++ b/actions/fgStatus.js
@@ -17,7 +17,8 @@
 
 const stateLib = require('@adobe/aio-lib-state');
 const crypto = require('crypto');
-const { getAioLogger } = require('./utils');
+const { getAioLogger, COPY_ACTION } = require('./utils');
+const appConfig = require('./appConfig');
 
 const FG_KEY = 'FLOODGATE';
 
@@ -61,11 +62,20 @@ class FgStatus {
      * @param {*} options statusKey is the key to be used to store
      * and actionType is the type of FG Action like copy or promote
      */
-    constructor({ action, statusKey, userDetails }) {
+    constructor({ action, statusKey, keySuffix, userDetails }) {
         this.lastTriggeredBy = userDetails?.oid;
         this.action = action || '';
-        this.storeKey = statusKey || FG_KEY;
+        this.storeKey = statusKey || `${this.getActionRootPath()}${keySuffix || ''}` || FG_KEY;
         this.logger = getAioLogger();
+    }
+
+    getActionRootPath() {
+        const { siteRootPath, siteFgRootPath } = appConfig.getConfig();
+        return this.action === COPY_ACTION ? siteRootPath : siteFgRootPath;
+    }
+
+    getStoreKey() {
+        return this.storeKey;
     }
 
     /**

--- a/actions/maint/maint.js
+++ b/actions/maint/maint.js
@@ -126,7 +126,7 @@ class MaintAction {
         return {};
     }
 
-    getActionStatusKey() {
+    getActionStatusKey(key) {
         // Split by comma (action, statusKey)
         let action = PROMOTE_ACTION;
         let statusKey;

--- a/actions/maint/maint.js
+++ b/actions/maint/maint.js
@@ -115,17 +115,28 @@ class MaintAction {
     }
 
     async stateStoreKey(key) {
-        // Split by comma (action, statusKey)
-        const fgStatus = new FgStatus({ action: PROMOTE_ACTION, statusKey: key });
+        const fgStatus = new FgStatus(this.getActionStatusKey(key));
         const data = await fgStatus.getStatusFromStateLib();
         return data;
     }
 
     async clearStateStore(key) {
-        // Split by comma (action, statusKey)
-        const fgStatus = new FgStatus({ action: PROMOTE_ACTION, statusKey: key });
+        const fgStatus = new FgStatus(this.getActionStatusKey(key));
         await fgStatus.clearState(true);
         return {};
+    }
+
+    getActionStatusKey() {
+        // Split by comma (action, statusKey)
+        let action = PROMOTE_ACTION;
+        let statusKey;
+        try {
+            const mtchs = key.match(/(.*?),(.*)/);
+            [, action, statusKey] = mtchs;
+        } catch (err) {
+            // Do Nothing
+        }
+        return { action, statusKey };
     }
 
     async updateTracker({ enable = '' }, ow) {

--- a/actions/maint/maint.js
+++ b/actions/maint/maint.js
@@ -134,7 +134,7 @@ class MaintAction {
             const mtchs = key.match(/(.*?),(.*)/);
             [, action, statusKey] = mtchs;
         } catch (err) {
-            // Do Nothing
+            logger.error(`Could not parse ${key}`);
         }
         return { action, statusKey };
     }

--- a/actions/promote/createBatch.js
+++ b/actions/promote/createBatch.js
@@ -50,9 +50,9 @@ async function main(params) {
     logMemUsage();
     let stepMsg;
     appConfig.setAppConfig(params);
-    const payload = appConfig.getPayload();
-    const fgStatus = new FgStatus({ action: PROMOTE_ACTION, statusKey: payload.fgRootFolder });
-    const batchManager = new BatchManager({ key: PROMOTE_ACTION, instanceKey: getInstanceKey({ fgRootFolder: payload.fgRootFolder }) });
+    const { payload, siteFgRootPath } = appConfig.getConfig();
+    const fgStatus = new FgStatus({ action: PROMOTE_ACTION });
+    const batchManager = new BatchManager({ key: PROMOTE_ACTION, instanceKey: getInstanceKey({ fgRootFolder: siteFgRootPath }) });
     await batchManager.init();
     // For current cleanup files before starting
     await batchManager.cleanupFiles();

--- a/actions/promote/promote.js
+++ b/actions/promote/promote.js
@@ -32,7 +32,7 @@ async function main(args) {
     let stepMsg;
     const payload = appConfig.getPayload();
     const userDetails = sharepointAuth.getUserDetails(payload.spToken);
-    const fgStatus = new FgStatus({ action: PROMOTE_ACTION, statusKey: payload.fgRootFolder, userDetails });
+    const fgStatus = new FgStatus({ action: PROMOTE_ACTION, userDetails });
     logger.info(`Promote action for ${payload.fgRootFolder} triggered by ${JSON.stringify(userDetails)}`);
     try {
         if (!payload.fgRootFolder) {

--- a/actions/promote/triggerNTrack.js
+++ b/actions/promote/triggerNTrack.js
@@ -132,10 +132,10 @@ async function checkBatchesInProg(fgRootFolder, actDtls, ow) {
         if (activationId && !done) {
             fgStatus = new FgStatus({
                 action: `${PROMOTE_BATCH}_${batchNumber}`,
-                suffixKey: `Batch_${batchNumber}`
+                keySuffix: `Batch_${batchNumber}`
             });
             batchInProg = await fgStatus?.getStatusFromStateLib().then((result) => {
-                if (result.action && FgStatus.isInProgress(result.action.status)) {
+                if (result?.action && FgStatus.isInProgress(result.action.status)) {
                     return true;
                 }
                 return false;

--- a/actions/promote/triggerNTrack.js
+++ b/actions/promote/triggerNTrack.js
@@ -49,7 +49,7 @@ async function main(params) {
     });
     const payload = appConfig.getPayload();
 
-    const fgStatus = new FgStatus({ action: PROMOTE_ACTION, statusKey: payload.fgRootFolder });
+    const fgStatus = new FgStatus({ action: PROMOTE_ACTION });
     try {
         if (!payload.fgRootFolder) {
             stepMsg = 'Required data is not available to proceed with FG Promote action.';
@@ -132,7 +132,7 @@ async function checkBatchesInProg(fgRootFolder, actDtls, ow) {
         if (activationId && !done) {
             fgStatus = new FgStatus({
                 action: `${PROMOTE_BATCH}_${batchNumber}`,
-                statusKey: `${fgRootFolder}~Batch_${batchNumber}`
+                suffixKey: `Batch_${batchNumber}`
             });
             batchInProg = await fgStatus?.getStatusFromStateLib().then((result) => {
                 if (result.action && FgStatus.isInProgress(result.action.status)) {

--- a/actions/promote/worker.js
+++ b/actions/promote/worker.js
@@ -39,7 +39,7 @@ async function main(params) {
     appConfig.setAppConfig(params);
     // Tracker uses the below hence change here might need change in tracker as well.
     const { payload, siteFgRootPath } = appConfig.getConfig();
-    const fgStatus = new FgStatus({ action: `${PROMOTE_BATCH}_${batchNumber}`, suffixKey: `Batch_${batchNumber}` });
+    const fgStatus = new FgStatus({ action: `${PROMOTE_BATCH}_${batchNumber}`, keySuffix: `Batch_${batchNumber}` });
     const batchManager = new BatchManager({ key: PROMOTE_ACTION, instanceKey: getInstanceKey({ fgRootFolder: siteFgRootPath }) });
     await batchManager.init({ batchNumber });
     try {

--- a/actions/promote/worker.js
+++ b/actions/promote/worker.js
@@ -38,9 +38,9 @@ async function main(params) {
     const { batchNumber } = params;
     appConfig.setAppConfig(params);
     // Tracker uses the below hence change here might need change in tracker as well.
-    const payload = appConfig.getPayload();
-    const fgStatus = new FgStatus({ action: `${PROMOTE_BATCH}_${batchNumber}`, statusKey: `${payload.fgRootFolder}~Batch_${batchNumber}` });
-    const batchManager = new BatchManager({ key: PROMOTE_ACTION, instanceKey: getInstanceKey({ fgRootFolder: payload.fgRootFolder }) });
+    const { payload, siteFgRootPath } = appConfig.getConfig();
+    const fgStatus = new FgStatus({ action: `${PROMOTE_BATCH}_${batchNumber}`, suffixKey: `Batch_${batchNumber}` });
+    const batchManager = new BatchManager({ key: PROMOTE_ACTION, instanceKey: getInstanceKey({ fgRootFolder: siteFgRootPath }) });
     await batchManager.init({ batchNumber });
     try {
         if (!payload.fgRootFolder) {

--- a/actions/sharepoint.js
+++ b/actions/sharepoint.js
@@ -363,22 +363,21 @@ async function getExcelTable(excelPath, tableName) {
     return [];
 }
 
-async function deleteFloodgateDir(fgRootFolder) {
+async function deleteFloodgateDir() {
     const logger = getAioLogger();
     logger.info('Deleting content started.');
-    const baseURI = `${appConfig.getConfig().fgSite}/drive/root:${fgRootFolder}`;
+    const { sp } = await getConfig();
     let deleteSuccess = false;
 
     const { fgDirPattern } = appConfig.getConfig();
     const fgRegExp = new RegExp(fgDirPattern);
     logger.info(fgRegExp);
-    if (fgRegExp.test(baseURI)) {
-        logger.info(`Deleting the folder ${baseURI} `);
+    if (fgRegExp.test(sp.api.file.update.fgBaseURI)) {
         const temp = '/temp';
-        const finalBaserURI = baseURI + temp;
+        const finalBaserURI = `${sp.api.file.delete.fgBaseURI}${temp}`;
+        logger.info(`Deleting the folder ${finalBaserURI} `);
         try {
-            const { sp } = await getConfig();
-            await deleteFile(sp, `${finalBaserURI}`);
+            await deleteFile(sp, finalBaserURI);
             deleteSuccess = true;
         } catch (error) {
             logger.info(`Error occurred when trying to delete files of main content tree ${error.message}`);

--- a/actions/status/status.js
+++ b/actions/status/status.js
@@ -42,10 +42,7 @@ async function main(args) {
             logger.error(payload);
         } else {
             const fgStatus = new FgStatus({ action: actionMap[type] });
-            logger.info(`Status key -- ${fgStatus.getStoreKey()}`);
             payload = await fgStatus.getStatusFromStateLib();
-
-            logger.info(`Status here -- ${JSON.stringify(payload)}`);
         }
     } catch (err) {
         logger.error(err);

--- a/actions/status/status.js
+++ b/actions/status/status.js
@@ -16,26 +16,23 @@
 ************************************************************************* */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-const { getAioLogger } = require('../utils');
+const appConfig = require('../appConfig');
+const { getAioLogger, COPY_ACTION } = require('../utils');
 const FgStatus = require('../fgStatus');
 
 // This returns the activation ID of the action that it called
 async function main(args) {
     const logger = getAioLogger();
     let payload;
-    let statusKey;
     try {
-        const { projectExcelPath, projectRoot } = args;
-        statusKey = projectRoot;
+        appConfig.setAppConfig(args);
+        const { projectExcelPath, projectRoot, action } = args;
         if (!projectExcelPath && !projectRoot) {
             payload = 'Status : Required data is not available to get the status.';
             logger.error(payload);
         } else {
-            if (projectExcelPath) {
-                statusKey = `${projectRoot}${projectExcelPath}`;
-            }
-            logger.info(`Status key -- ${statusKey}`);
-            const fgStatus = new FgStatus({ statusKey });
+            const fgStatus = new FgStatus({ action });
+            logger.info(`Status key -- ${fgStatus.getStoreKey()}`);
             payload = await fgStatus.getStatusFromStateLib();
 
             logger.info(`Status here -- ${JSON.stringify(payload)}`);

--- a/actions/status/status.js
+++ b/actions/status/status.js
@@ -17,8 +17,16 @@
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 const appConfig = require('../appConfig');
-const { getAioLogger, COPY_ACTION } = require('../utils');
+const {
+    getAioLogger, COPY_ACTION, PROMOTE_ACTION, DELETE_ACTION
+} = require('../utils');
 const FgStatus = require('../fgStatus');
+
+const actionMap = {
+    copy: COPY_ACTION,
+    promote: PROMOTE_ACTION,
+    delete: DELETE_ACTION
+};
 
 // This returns the activation ID of the action that it called
 async function main(args) {
@@ -26,12 +34,14 @@ async function main(args) {
     let payload;
     try {
         appConfig.setAppConfig(args);
-        const { projectExcelPath, projectRoot, action } = args;
-        if (!projectExcelPath && !projectRoot) {
+        const {
+            type, shareUrl, fgShareUrl
+        } = args;
+        if (!type || !(shareUrl || fgShareUrl)) {
             payload = 'Status : Required data is not available to get the status.';
             logger.error(payload);
         } else {
-            const fgStatus = new FgStatus({ action });
+            const fgStatus = new FgStatus({ action: actionMap[type] });
             logger.info(`Status key -- ${fgStatus.getStoreKey()}`);
             payload = await fgStatus.getStatusFromStateLib();
 

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -21,6 +21,7 @@ application:
           groupCheckUrl: $GROUP_CHECK_URL
           fgUserGroups: $FG_USER_GROUPS
           fgAdminGroups: $FG_ADMIN_GROUPS
+          siteRootPathRex: $SITE_ROOT_PATH_REX
         actions:
           copy:
             function: actions/copy/copy.js


### PR DESCRIPTION
Updating the instance path and status key to support drive. E.g. if the a www is present in two different drives like CC and test Enhance the instance path and status key configuration to accommodate different drives, such as CC and test, when the common root path (e.g. "www") is present in multiple locations.

Changes -
Extract the site absolute path from shareUrl(s).
Get the key based on action instead passing from action and is based on absolute path. **(One ENV filed is added SITE_ROOT_PATH_REX=.*/sites(/.*)< )** Instead of instance based on root folder base it on absolute folder. Example -
Store Key (for copy) - /adobecom/Shared%20Documents/milo Instance Path - milo-floodgate/batching/promoteAction/instance_adobecom_Shared_20Documents_milo_pink

Status Action (UI Code Adjustments Required for Milo):
Instead of projectRoot the shareUrls are passed along with action type. The instance/store key generation on aio is reused.
```
    For Copy
    {
        "type": "copy",
        "projectExcelPath": "/drafts/floodgate/projects/test/sample.xlsx",
        "shareUrl": "...../Shared%20Documents/milo<relativePath>?web=1",
    }
```
    
```
    For Promote
    {
        "type": "promote",
        "fgShareUrl": "....../Shared%20Documents/milo-pink<relativePath>?web=1"
    }
```
