### PR TITLE
MWPW-131427: Fix for user in group check

### DIFF
--- a/actions/fgUser.js
+++ b/actions/fgUser.js
@@ -73,7 +73,7 @@ class FgUser {
 
     async isInUserGroup() {
         const grpIds = appConfig.getConfig().fgUserGroups;
-        return !grpIds?.length ? true : this.isInGroups(grpIds);
+        return !grpIds?.length ? false : this.isInGroups(grpIds);
     }
 
     async isUser() {


### PR DESCRIPTION
- User needs to be in the Floodgate User IAM group to trigger the APIs.
- The same applies to a developer as well if they are testing the API using their own AIO workspace.