### PR TITLE
MWPW-135444 Update preview/publish url for index doc

### DIFF
--- a/actions/utils.js
+++ b/actions/utils.js
@@ -33,6 +33,9 @@ function handleExtension(path) {
     if (path.endsWith('.xlsx')) {
         return path.replace('.xlsx', '.json');
     }
+    if (path.endsWith('/index.docx')) {
+        return path.substring(0, path.lastIndexOf('/index.docx') + 1);
+    }
     if (path.endsWith('.docx')) {
         return path.substring(0, path.lastIndexOf('.'));
     }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -31,4 +31,7 @@ describe('handleExtension', () => {
     test('svg path', () => {
         expect(utils.handleExtension('/path/to/file.svg')).toEqual('/path/to/file.svg');
     });
+    test('docx path', () => {
+        expect(utils.handleExtension('/path/to/index.docx')).toEqual('/path/to/');
+    });
 });


### PR DESCRIPTION
For preview web url needs to be used and hence for /index.doc should be replaced with /

Resolves (issues mentioned in MWPW-138850)

Tested: Pre and Post Promote runs
![image](https://github.com/adobecom/milo-fg/assets/125877471/e0cd3288-389e-49fe-ad6c-59199d6161e9)
