### PR TITLE
MWPW-138362 Trigger next promote batch after copy is complete 

### DIFF
--- a/actions/fgStatus.js
+++ b/actions/fgStatus.js
@@ -40,6 +40,13 @@ class FgStatus {
     };
 
     /**
+     * Status constants
+     */
+    static PROJECT_STAGE = {
+        PROMOTE_COPY_STATUS: 'promoteCopyStatus',
+    };
+
+    /**
      * Template that will be populated and stored in state
      */
     storeStatusTmpl = {
@@ -51,7 +58,8 @@ class FgStatus {
             activationId: '',
             startTime: '',
             endTime: '',
-            batchesInfo: []
+            batchesInfo: [],
+            details: {}
         }
     };
 
@@ -124,7 +132,7 @@ class FgStatus {
      * @returns progress object which is stored in the store
      */
     async updateStatusToStateLib({
-        status, statusMessage, activationId, action, startTime, endTime, batches
+        status, statusMessage, activationId, action, startTime, endTime, batches, details
     }) {
         try {
             await this.getStatusFromStateLib().then(async (result) => {
@@ -145,12 +153,16 @@ class FgStatus {
                     if (endTime) {
                         this.storeStatus.action.endTime = endTime;
                     }
+                    if (details) {
+                        this.storeStatus.action.details = details;
+                    }
                 } else {
                     this.storeStatus.action.status = status;
                     this.storeStatus.action.message = statusMessage;
                     this.storeStatus.action.activationId = activationId;
                     this.storeStatus.action.startTime = startTime || this.storeStatus.action.startTime;
                     this.storeStatus.action.endTime = endTime || this.storeStatus.action.endTime;
+                    this.storeStatus.action.details = details || this.storeStatus.action.details;
                 }
                 this.storeStatus.action.batches = batches || this.storeStatus.action.batches;
                 this.storeStatus.action.type = action || this.action || this.storeStatus.action.type;

--- a/actions/fgStatus.js
+++ b/actions/fgStatus.js
@@ -153,16 +153,15 @@ class FgStatus {
                     if (endTime) {
                         this.storeStatus.action.endTime = endTime;
                     }
-                    if (details) {
-                        this.storeStatus.action.details = details;
-                    }
                 } else {
                     this.storeStatus.action.status = status;
                     this.storeStatus.action.message = statusMessage;
                     this.storeStatus.action.activationId = activationId;
                     this.storeStatus.action.startTime = startTime || this.storeStatus.action.startTime;
                     this.storeStatus.action.endTime = endTime || this.storeStatus.action.endTime;
-                    this.storeStatus.action.details = details || this.storeStatus.action.details;
+                }
+                if (details) {
+                    this.storeStatus.action.details = { ...this.storeStatus.action.details, ...details };
                 }
                 this.storeStatus.action.batches = batches || this.storeStatus.action.batches;
                 this.storeStatus.action.type = action || this.action || this.storeStatus.action.type;

--- a/actions/promote/postCopyWorker.js
+++ b/actions/promote/postCopyWorker.js
@@ -89,7 +89,8 @@ async function previewPublish(doPublish, batchManager) {
     const currBatchLbl = `Batch-${currentBatch.getBatchNumber()}`;
     const allFloodgatedFiles = await currentBatch.getFiles();
     const promotedFiles = allFloodgatedFiles.map((e) => e.file.filePath);
-    const failedPromotes = await currentBatch.getResultsContent()?.failedPromotes || [];
+    const resultsContent = await currentBatch.getResultsContent() || [];
+    const failedPromotes = resultsContent.failedPromotes || [];
     const prevPaths = promotedFiles.filter((item) => !failedPromotes.includes(item)).map((e) => handleExtension(e));
     logger.info(`Post promote files for ${currBatchLbl} are ${prevPaths?.length}`);
 

--- a/actions/promote/postCopyWorker.js
+++ b/actions/promote/postCopyWorker.js
@@ -1,0 +1,140 @@
+/* eslint-disable no-await-in-loop */
+/* ************************************************************************
+* ADOBE CONFIDENTIAL
+* ___________________
+*
+* Copyright 2023 Adobe
+* All Rights Reserved.
+*
+* NOTICE: All information contained herein is, and remains
+* the property of Adobe and its suppliers, if any. The intellectual
+* and technical concepts contained herein are proprietary to Adobe
+* and its suppliers and are protected by all applicable intellectual
+* property laws, including trade secret and copyright laws.
+* Dissemination of this information or reproduction of this material
+* is strictly forbidden unless prior written permission is obtained
+* from Adobe.
+************************************************************************* */
+const openwhisk = require('openwhisk');
+const {
+    handleExtension, getAioLogger, logMemUsage, getInstanceKey, PROMOTE_ACTION, PROMOTE_BATCH
+} = require('../utils');
+const helixUtils = require('../helixUtils');
+const FgAction = require('../FgAction');
+const FgStatus = require('../fgStatus');
+const BatchManager = require('../batchManager');
+const appConfig = require('../appConfig');
+
+async function main(params) {
+    const logger = getAioLogger();
+    logMemUsage();
+    const { batchNumber } = params;
+    const valParams = {
+        statParams: ['fgRootFolder', 'projectExcelPath'],
+        actParams: ['adminPageUri'],
+        checkUser: false,
+        checkStatus: false,
+        checkActivation: false
+    };
+    const ow = openwhisk();
+    // Initialize action
+    logger.info(`Post promote worker started for batch ${batchNumber}`);
+    const fgAction = new FgAction(`${PROMOTE_BATCH}_${batchNumber}`, params);
+    fgAction.init({ ow, skipUserDetails: true, fgStatusParams: { keySuffix: `Batch_${batchNumber}` } });
+    const { fgStatus } = fgAction.getActionParams();
+    const payload = appConfig.getPayload();
+    const fgRootFolder = appConfig.getSiteFgRootPath();
+
+    let respPayload;
+    const batchManager = new BatchManager({ key: PROMOTE_ACTION, instanceKey: getInstanceKey({ fgRootFolder }) });
+    await batchManager.init({ batchNumber });
+    try {
+        const vStat = await fgAction.validateAction(valParams);
+        if (vStat && vStat.code !== 200) {
+            return exitAction(vStat);
+        }
+
+        respPayload = `Previewing/Publishing promoted content for ${batchNumber}`;
+        await fgStatus.updateStatusToStateLib({
+            status: FgStatus.PROJECT_STATUS.IN_PROGRESS,
+            statusMessage: respPayload
+        });
+        logger.info(respPayload);
+        respPayload = await previewPublish(payload.doPublish, batchManager);
+
+        await fgStatus.updateStatusToStateLib({
+            status: FgStatus.PROJECT_STATUS.COMPLETED,
+            statusMessage: respPayload
+        });
+    } catch (err) {
+        await fgStatus.updateStatusToStateLib({
+            status: FgStatus.PROJECT_STATUS.COMPLETED_WITH_ERROR,
+            statusMessage: err.message,
+        });
+        logger.error(err);
+        respPayload = err;
+    }
+
+    return exitAction({
+        body: respPayload,
+    });
+}
+
+async function previewPublish(doPublish, batchManager) {
+    const logger = getAioLogger();
+
+    let stepMsg = 'Getting all batch files.';
+    // Get the batch files using the batchmanager for the assigned batch and process them
+    const currentBatch = await batchManager.getCurrentBatch();
+    const currBatchLbl = `Batch-${currentBatch.getBatchNumber()}`;
+    const allFloodgatedFiles = await currentBatch.getFiles();
+    const promotedFiles = allFloodgatedFiles.map((e) => e.file.filePath);
+    const failedPromotes = await currentBatch.getResultsContent()?.failedPromotes || [];
+    const prevPaths = promotedFiles.filter((item) => !failedPromotes.includes(item)).map((e) => handleExtension(e));
+    logger.info(`Post promote files for ${currBatchLbl} are ${prevPaths?.length}`);
+    logger.info(`Post promote files for ${JSON.stringify(prevPaths?.length)}`);
+
+    logger.info('Previewing promoted files.');
+    let previewStatuses = [];
+    let publishStatuses = [];
+    if (helixUtils.canBulkPreviewPublish()) {
+        previewStatuses = await helixUtils.bulkPreviewPublish(prevPaths, helixUtils.getOperations().PREVIEW);
+        stepMsg = 'Completed generating Preview for promoted files.';
+        logger.info(stepMsg);
+
+        if (doPublish) {
+            stepMsg = 'Publishing promoted files.';
+            logger.info(stepMsg);
+            publishStatuses = await helixUtils.bulkPreviewPublish(prevPaths, helixUtils.getOperations().LIVE);
+            stepMsg = 'Completed Publishing for promoted files';
+            logger.info(stepMsg);
+        }
+    }
+
+    const failedPreviews = previewStatuses.filter((status) => !status.success)
+        .map((status) => status.path);
+    const failedPublishes = publishStatuses.filter((status) => !status.success)
+        .map((status) => status.path);
+    logger.info(`Post promote ${currBatchLbl}, Prm: ${failedPromotes?.length}, Prv: ${failedPreviews?.length}, Pub: ${failedPublishes?.length}`);
+
+    if (failedPromotes.length > 0 || failedPreviews.length > 0 || failedPublishes.length > 0) {
+        stepMsg = 'Error occurred when promoting floodgated content. Check project excel sheet for additional information.';
+        logger.info(stepMsg);
+        // Write the information to batch manifest
+        currentBatch.writeResults({ failedPromotes, failedPreviews, failedPublishes });
+        throw new Error(stepMsg);
+    } else {
+        stepMsg = `Promoted floodgate for ${currBatchLbl} successfully`;
+        logger.info(stepMsg);
+    }
+    logMemUsage();
+    stepMsg = `All tasks for floodgate promote of ${currBatchLbl} is completed`;
+    return stepMsg;
+}
+
+function exitAction(resp) {
+    appConfig.removePayload();
+    return resp;
+}
+
+exports.main = main;

--- a/actions/promote/postCopyWorker.js
+++ b/actions/promote/postCopyWorker.js
@@ -54,14 +54,14 @@ async function main(params) {
             return exitAction(vStat);
         }
 
-        respPayload = `Previewing/Publishing promoted content for ${batchNumber}`;
+        respPayload = 'Previewing/Publishing promoted content';
+        logger.info(respPayload);
         await fgStatus.updateStatusToStateLib({
             status: FgStatus.PROJECT_STATUS.IN_PROGRESS,
             statusMessage: respPayload
         });
-        logger.info(respPayload);
-        respPayload = await previewPublish(payload.doPublish, batchManager);
 
+        respPayload = await previewPublish(payload.doPublish, batchManager);
         await fgStatus.updateStatusToStateLib({
             status: FgStatus.PROJECT_STATUS.COMPLETED,
             statusMessage: respPayload
@@ -89,7 +89,7 @@ async function previewPublish(doPublish, batchManager) {
     const currBatchLbl = `Batch-${currentBatch.getBatchNumber()}`;
     const allFloodgatedFiles = await currentBatch.getFiles();
     const promotedFiles = allFloodgatedFiles.map((e) => e.file.filePath);
-    const resultsContent = await currentBatch.getResultsContent() || [];
+    const resultsContent = await currentBatch.getResultsContent() || {};
     const failedPromotes = resultsContent.failedPromotes || [];
     const prevPaths = promotedFiles.filter((item) => !failedPromotes.includes(item)).map((e) => handleExtension(e));
     logger.info(`Post promote files for ${currBatchLbl} are ${prevPaths?.length}`);
@@ -123,12 +123,10 @@ async function previewPublish(doPublish, batchManager) {
         // Write the information to batch manifest
         currentBatch.writeResults({ failedPromotes, failedPreviews, failedPublishes });
         throw new Error(stepMsg);
-    } else {
-        stepMsg = `Promoted floodgate for ${currBatchLbl} successfully`;
-        logger.info(stepMsg);
     }
     logMemUsage();
-    stepMsg = `All tasks for floodgate promote of ${currBatchLbl} is completed`;
+    logger.info(`All tasks for promote ${currBatchLbl} is completed`);
+    stepMsg = 'All tasks for floodgate promote is completed';
     return stepMsg;
 }
 

--- a/actions/promote/postCopyWorker.js
+++ b/actions/promote/postCopyWorker.js
@@ -92,7 +92,6 @@ async function previewPublish(doPublish, batchManager) {
     const failedPromotes = await currentBatch.getResultsContent()?.failedPromotes || [];
     const prevPaths = promotedFiles.filter((item) => !failedPromotes.includes(item)).map((e) => handleExtension(e));
     logger.info(`Post promote files for ${currBatchLbl} are ${prevPaths?.length}`);
-    logger.info(`Post promote files for ${JSON.stringify(prevPaths?.length)}`);
 
     logger.info('Previewing promoted files.');
     let previewStatuses = [];

--- a/actions/promote/triggerNTrack.js
+++ b/actions/promote/triggerNTrack.js
@@ -63,7 +63,13 @@ async function main(params) {
             return exitAction(vStat);
         }
 
-        respPayload = 'Getting status of all reference activation.';
+        const promoteProg = batchesInfo.reduce((acc, item) => {
+            acc.total += 1;
+            acc.prog += item.done || item.activationId ? 1 : 0;
+            return acc;
+        }, { total: 0, prog: 0 });
+
+        respPayload = promoteProg.prog ? `Promoting batch ${promoteProg.prog} / ${promoteProg.total}.` : 'Promoting files.';
         await fgStatus.updateStatusToStateLib({
             status: FgStatus.PROJECT_STATUS.IN_PROGRESS,
             statusMessage: respPayload

--- a/actions/promote/triggerNTrack.js
+++ b/actions/promote/triggerNTrack.js
@@ -206,7 +206,10 @@ async function triggerPromoteWorkerAction(ow, params, fgStatus) {
         // attaching activation id to the status
         await fgStatus.updateStatusToStateLib({
             status: FgStatus.PROJECT_STATUS.IN_PROGRESS,
-            activationId: result.activationId
+            activationId: result.activationId,
+            details: {
+                [FgStatus.PROJECT_STAGE.PROMOTE_COPY_STATUS]: FgStatus.PROJECT_STATUS.STARTED
+            }
         });
         return {
             batchNumber: params.batchNumber,

--- a/actions/promote/triggerNTrack.js
+++ b/actions/promote/triggerNTrack.js
@@ -70,13 +70,15 @@ async function main(params) {
         });
 
         // Check to see all batches are complete
-        const batchCheckResp = await checkBatchesInProg(payload.fgRootFolder, batchesInfo, ow);
-        const { anyInProg, allDone } = batchCheckResp;
+        const { anyInProg, allCopyDone } = await checkBatchesInProg(payload.fgRootFolder, batchesInfo, ow);
         await batchManager.writeToInstanceFile(instanceContent);
 
         // Collect status and mark as complete
-        if (allDone) {
-            await completePromote(payload.projectExcelPath, batchesInfo, batchManager, fgStatus);
+        if (allCopyDone) {
+            const allDone = await checkPostPromoteStatus(payload.fgRootFolder, batchesInfo);
+            if (allDone) {
+                await completePromote(payload.projectExcelPath, batchesInfo, batchManager, fgStatus);
+            }
             await batchManager.writeToInstanceFile(instanceContent);
         } else if (!anyInProg) {
             // Trigger next activation
@@ -125,11 +127,54 @@ async function checkBatchesInProg(fgRootFolder, actDtls, ow) {
     let fgStatus;
     let batchState;
     let batchInProg = false;
+    let allCopyDone = true;
+    let counter = 0;
+    for (; counter < actDtls?.length && !batchInProg; counter += 1) {
+        const {
+            batchNumber,
+            activationId,
+            copyDone
+        } = actDtls[counter];
+        if (activationId && !copyDone) {
+            fgStatus = new FgStatus({
+                action: `${PROMOTE_BATCH}_${batchNumber}`,
+                keySuffix: `Batch_${batchNumber}`
+            });
+            batchState = await fgStatus.getStatusFromStateLib().then((result) => result?.action);
+            // Track and trigger called before the state is marked in progress with activation id
+            batchInProg = false || (!batchState?.status && !batchState?.actInProgress) || FgStatus.isInProgress(batchState?.details?.[FgStatus.PROJECT_STAGE.PROMOTE_COPY_STATUS]);
+            if (batchInProg) batchInProg = await actInProgress(ow, activationId, batchInProg);
+            if (!batchInProg) {
+                actDtls[counter].copyDone = true;
+                actDtls[counter].startTime = batchState?.startTime;
+                actDtls[counter].status = batchState?.status;
+            } else if (batchState) {
+                actDtls[counter].startTime = batchState.startTime;
+                actDtls[counter].status = batchState.status;
+            }
+            allCopyDone &&= !batchInProg;
+        } else {
+            allCopyDone &&= copyDone;
+        }
+    }
+
+    return { anyInProg: batchInProg, allCopyDone };
+}
+
+async function checkPostPromoteStatus(fgRootFolder, actDtls) {
+    let fgStatus;
+    let batchState;
+    let batchInProg = false;
     let allDone = true;
     let counter = 0;
     for (; counter < actDtls?.length && !batchInProg; counter += 1) {
-        const { batchNumber, activationId, done } = actDtls[counter];
-        if (activationId && !done) {
+        const {
+            batchNumber,
+            activationId,
+            copyDone,
+            done
+        } = actDtls[counter];
+        if (activationId && copyDone && !done) {
             fgStatus = new FgStatus({
                 action: `${PROMOTE_BATCH}_${batchNumber}`,
                 keySuffix: `Batch_${batchNumber}`
@@ -137,23 +182,18 @@ async function checkBatchesInProg(fgRootFolder, actDtls, ow) {
             batchState = await fgStatus.getStatusFromStateLib().then((result) => result?.action);
             // Track and trigger called before the state is marked in progress with activation id
             batchInProg = false || (!batchState?.status && !batchState?.actInProgress) || FgStatus.isInProgress(batchState?.status);
-            if (batchInProg) batchInProg = await actInProgress(ow, activationId, batchInProg);
             if (!batchInProg) {
                 actDtls[counter].done = true;
                 actDtls[counter].startTime = batchState?.startTime;
                 actDtls[counter].endTime = batchState?.endTime;
                 actDtls[counter].status = batchState?.status;
-            } else if (batchState) {
-                actDtls[counter].startTime = batchState.startTime;
-                actDtls[counter].status = batchState.status;
             }
             allDone &&= !batchInProg;
         } else {
             allDone &&= done;
         }
     }
-
-    return { anyInProg: batchInProg, allDone };
+    return allDone;
 }
 
 async function triggerPromoteWorkerAction(ow, params, fgStatus) {

--- a/actions/promote/triggerNTrack.js
+++ b/actions/promote/triggerNTrack.js
@@ -220,7 +220,7 @@ async function triggerPromoteWorkerAction(ow, params, fgStatus) {
             status: FgStatus.PROJECT_STATUS.FAILED,
             statusMessage: `Failed to invoke actions ${err.message} for batch ${params.batchNumber}`
         });
-        logger.error('Failed to invoke actions', err);
+        logger.error(`Failed for batch ${params.batchNumber}`, err);
         return {
             batchNumber: params.batchNumber
         };

--- a/actions/promote/worker.js
+++ b/actions/promote/worker.js
@@ -223,9 +223,9 @@ async function triggerPostCopy(ow, params, fgStatus) {
     }).catch(async (err) => {
         await fgStatus.updateStatusToStateLib({
             status: FgStatus.PROJECT_STATUS.FAILED,
-            statusMessage: `Failed to invoke actions ${err.message} for batch ${params.batchNumber}`
+            statusMessage: `Failed to invoke actions ${err.message}`
         });
-        getAioLogger().error('Failed to invoke actions', err);
+        getAioLogger().error(`Failed to invoke actions for batch ${params.batchNumber}`, err);
         return {};
     });
 }

--- a/actions/promote/worker.js
+++ b/actions/promote/worker.js
@@ -82,6 +82,8 @@ async function main(params) {
                 [FgStatus.PROJECT_STAGE.PROMOTE_COPY_STATUS]: FgStatus.PROJECT_STATUS.COMPLETED
             }
         });
+        // A small delay before trigger
+        await delay(DELAY_TIME_PROMOTE);
         await triggerPostCopy(ow, { ...appConfig.getPassthruParams(), batchNumber }, fgStatus);
     } catch (err) {
         await fgStatus.updateStatusToStateLib({
@@ -211,8 +213,8 @@ async function triggerPostCopy(ow, params, fgStatus) {
         params
     }).then(async (result) => {
         // attaching activation id to the status
+        // Its possible status is updated in post copy action before this callback is called.
         await fgStatus.updateStatusToStateLib({
-            status: FgStatus.PROJECT_STATUS.IN_PROGRESS,
             postPromoteActivationId: result.activationId
         });
         return {

--- a/actions/promote/worker.js
+++ b/actions/promote/worker.js
@@ -21,9 +21,8 @@ const {
     getAuthorizedRequestOption, saveFile, getFileUsingDownloadUrl, fetchWithRetry
 } = require('../sharepoint');
 const {
-    getAioLogger, handleExtension, delay, logMemUsage, getInstanceKey, PROMOTE_ACTION, PROMOTE_BATCH
+    getAioLogger, delay, logMemUsage, getInstanceKey, PROMOTE_ACTION, PROMOTE_BATCH
 } = require('../utils');
-const helixUtils = require('../helixUtils');
 const FgAction = require('../FgAction');
 const FgStatus = require('../fgStatus');
 const BatchManager = require('../batchManager');
@@ -44,7 +43,7 @@ async function main(params) {
     };
     const ow = openwhisk();
     // Initialize action
-    logger.info(`Worker for ${PROMOTE_BATCH}_${batchNumber} started`);
+    logger.info(`Promote started for ${batchNumber}`);
     const fgAction = new FgAction(`${PROMOTE_BATCH}_${batchNumber}`, params);
     fgAction.init({ ow, skipUserDetails: true, fgStatusParams: { keySuffix: `Batch_${batchNumber}` } });
     const { fgStatus } = fgAction.getActionParams();
@@ -63,16 +62,27 @@ async function main(params) {
         await fgStatus.clearState();
 
         respPayload = 'Getting all files to be promoted.';
+        logger.info(respPayload);
         await fgStatus.updateStatusToStateLib({
             status: FgStatus.PROJECT_STATUS.STARTED,
-            statusMessage: respPayload
+            statusMessage: respPayload,
+            details: {
+                [FgStatus.PROJECT_STAGE.PROMOTE_COPY_STATUS]: FgStatus.PROJECT_STATUS.IN_PROGRESS
+            }
+
         });
+        respPayload = 'Promote files';
         logger.info(respPayload);
         respPayload = await promoteFloodgatedFiles(payload.doPublish, batchManager);
+        respPayload = `Promoted files ${JSON.stringify(respPayload)}`;
         await fgStatus.updateStatusToStateLib({
-            status: FgStatus.PROJECT_STATUS.COMPLETED,
-            statusMessage: respPayload
+            status: FgStatus.PROJECT_STATUS.IN_PROGRESS,
+            statusMessage: respPayload,
+            details: {
+                [FgStatus.PROJECT_STAGE.PROMOTE_COPY_STATUS]: FgStatus.PROJECT_STATUS.COMPLETED
+            }
         });
+        await triggerPostCopy(ow, { ...appConfig.getPassthruParams(), batchNumber }, fgStatus);
     } catch (err) {
         await fgStatus.updateStatusToStateLib({
             status: FgStatus.PROJECT_STATUS.COMPLETED_WITH_ERROR,
@@ -175,45 +185,47 @@ async function promoteFloodgatedFiles(doPublish, batchManager) {
     stepMsg = `Completed promoting all documents in the batch ${currBatchLbl}`;
     logger.info(stepMsg);
 
-    logger.info('Previewing promoted files.');
-    let previewStatuses = [];
-    let publishStatuses = [];
-    if (helixUtils.canBulkPreviewPublish()) {
-        const prevPaths = promoteStatuses.filter((ps) => ps.success).map((ps) => handleExtension(ps.srcPath));
-        previewStatuses = await helixUtils.bulkPreviewPublish(prevPaths, helixUtils.getOperations().PREVIEW);
-        stepMsg = 'Completed generating Preview for promoted files.';
-        logger.info(stepMsg);
-
-        if (doPublish) {
-            stepMsg = 'Publishing promoted files.';
-            logger.info(stepMsg);
-            publishStatuses = await helixUtils.bulkPreviewPublish(prevPaths, helixUtils.getOperations().LIVE);
-            stepMsg = 'Completed Publishing for promoted files';
-            logger.info(stepMsg);
-        }
-    }
-
     const failedPromotes = promoteStatuses.filter((status) => !status.success)
         .map((status) => status.srcPath || 'Path Info Not available');
-    const failedPreviews = previewStatuses.filter((status) => !status.success)
-        .map((status) => status.path);
-    const failedPublishes = publishStatuses.filter((status) => !status.success)
-        .map((status) => status.path);
-    logger.info(`${currBatchLbl}, Prm: ${failedPromotes?.length}, Prv: ${failedPreviews?.length}, Pub: ${failedPublishes?.length}`);
+    logger.info(`Promote ${currBatchLbl}, Prm: ${failedPromotes?.length}`);
 
-    if (failedPromotes.length > 0 || failedPreviews.length > 0 || failedPublishes.length > 0) {
+    if (failedPromotes.length > 0) {
         stepMsg = 'Error occurred when promoting floodgated content. Check project excel sheet for additional information.';
         logger.info(stepMsg);
         // Write the information to batch manifest
-        currentBatch.writeResults({ failedPromotes, failedPreviews, failedPublishes });
-        throw new Error(stepMsg);
+        await currentBatch.writeResults({ failedPromotes });
     } else {
         stepMsg = `Promoted floodgate for ${currBatchLbl} successfully`;
         logger.info(stepMsg);
     }
     logMemUsage();
-    stepMsg = `All tasks for floodgate promote of ${currBatchLbl} is completed`;
+    stepMsg = `Floodgate promote (copy) of ${currBatchLbl} is completed`;
     return stepMsg;
+}
+
+async function triggerPostCopy(ow, params, fgStatus) {
+    return ow.actions.invoke({
+        name: 'milo-fg/post-copy-worker',
+        blocking: false, // this is the flag that instructs to execute the worker asynchronous
+        result: false,
+        params
+    }).then(async (result) => {
+        // attaching activation id to the status
+        await fgStatus.updateStatusToStateLib({
+            status: FgStatus.PROJECT_STATUS.IN_PROGRESS,
+            postPromoteActivationId: result.activationId
+        });
+        return {
+            postPromoteActivationId: result.activationId
+        };
+    }).catch(async (err) => {
+        await fgStatus.updateStatusToStateLib({
+            status: FgStatus.PROJECT_STATUS.FAILED,
+            statusMessage: `Failed to invoke actions ${err.message} for batch ${params.batchNumber}`
+        });
+        getAioLogger().error('Failed to invoke actions', err);
+        return {};
+    });
 }
 
 function exitAction(resp) {

--- a/actions/promoteStatus/promoteStatus.js
+++ b/actions/promoteStatus/promoteStatus.js
@@ -83,7 +83,7 @@ async function main(args) {
         }
 
         // Starts
-        const { siteFgRootPath } = appConfig.getConfig();
+        const siteFgRootPath = appConfig.getSiteFgRootPath();
         const batchManager = new BatchManager({ key: PROMOTE_ACTION, instanceKey: getInstanceKey({ fgRootFolder: siteFgRootPath }) });
         await batchManager.init({ batchNumber });
         const currentBatch = batchNumber ? await batchManager.getCurrentBatch() : null;
@@ -117,7 +117,7 @@ async function main(args) {
     }
 
     return exitAction({
-        payload,
+        ...payload
     });
 }
 

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -79,6 +79,14 @@ application:
               timeout: 3600000
               memorySize: 1024
               concurrency: 5
+          post-copy-worker:
+            function: actions/promote/postCopyWorker.js
+            web: 'no'
+            runtime: nodejs:16
+            inputs:
+              LOG_LEVEL: debug
+            limits:
+              timeout: 3600000
           promote-trigger-n-track:
             function: actions/promote/triggerNTrack.js
             web: 'no'


### PR DESCRIPTION
A state field is added to indicate copy completion. `"details":{"promoteCopyStatus":"COMPLETED"}}}` Trigger and track checks for this field, and if it's COMPLETE, trigger the next batch, while the preview and promote are moved to postPromoteWorker. The overall completion of the batch is still tracked via batch status. 
Example:
`{"action":{"lastTriggeredBy":"","type":"promoteBatch_2","status":"IN PROGRESS","message":"Previewing/Publishing promoted content for 2","activationId":"....","startTime":"2023-11-09T12:59:19.645Z","endTime":"","batchesInfo":[],"details":{"promoteCopyStatus":"COMPLETED"}}}`

Tested with a Promote (Below is batching flow)
_2023-11-09T18:02:23.499Z - Promote Started for 1 (Promote Status - IN PROGRESS)
2023-11-09T18:03:46.199Z - Promote Copy Completed for 1
2023-11-09T18:03:50.342Z - Previewing/Publishing for 1 
     *started ("status":"IN PROGRESS", "details":{"promoteCopyStatus":"COMPLETED"})
2023-11-09T18:04:14.661Z - Promote started for 2
2023-11-09T18:05:41.809Z - Batch 1 completed (Post Promote Complete)
2023-11-09T18:07:26.451Z - Promote Copy Completed for 2
2023-11-09T18:07:26.731Z - Previewing/Publishing for 2
2023-11-09T18:08:14.740Z - Promote started for 3
2023-11-09T18:09:17.493Z - Batch 2 completed (Post Promote Complete)
2023-11-09T18:09:50.536Z - Promote Copy Completed for 3
2023-11-09T18:09:50.627Z - Previewing/Publishing for 3
2023-11-09T18:10:59.299Z - Batch 3 completed (Post Promote Complete)
2023-11-09T18:11:19.290Z - All Promote Tasks Completed (Promote Status - COMPLETE)_