### PR TITLE
show FAILED when all copies fail

### DIFF
--- a/actions/copy/worker.js
+++ b/actions/copy/worker.js
@@ -175,8 +175,10 @@ async function floodgateContent(projectExcelPath, projectDetail, fgStatus, fgCol
     const payload = fgErrors ?
         'Error occurred when floodgating content. Check project excel sheet for additional information.' :
         'All tasks for Floodgate Copy completed';
+    let status = fgErrors ? FgStatus.PROJECT_STATUS.COMPLETED_WITH_ERROR : FgStatus.PROJECT_STATUS.COMPLETED;
+    status = fgErrors && failedCopies.length === copyStatuses.length ? FgStatus.PROJECT_STATUS.FAILED : status;
     await fgStatus.updateStatusToStateLib({
-        status: fgErrors ? FgStatus.PROJECT_STATUS.COMPLETED_WITH_ERROR : FgStatus.PROJECT_STATUS.COMPLETED,
+        status,
         statusMessage: payload
     });
 


### PR DESCRIPTION
Ticket: https://jira.corp.adobe.com/browse/MWPW-138925 
If all the copies fail during a COPY action, it still shows 'COMPLETED WITH ERROR'. This is not indicative of the failure of the copies. The code has been modified to handle this scenario. If all copies fail, then the status would be FAILED and the ui would a red status card.