### PR TITLE
MWPW-139335 Handle filename with caps or spaces or underscores

### DIFF
--- a/actions/sharepoint.js
+++ b/actions/sharepoint.js
@@ -252,7 +252,6 @@ async function createSessionAndUploadFile(sp, file, dest, filename, isFloodgate)
  * Folders to create would be [/a/b, /a/c/d]
  * This triggers async and waits for batch to complete. These are small batches so should be fast.
  * The $batch can be used in future to submit only one URL
- * @param {*} adminPageUri AdminPageURI for getting configs
  * @param {*} srcPathList Paths of files for which folder creating is needed
  * @param {*} isFloodgate Is floodgate flag
  * @returns Create folder status

--- a/actions/utils.js
+++ b/actions/utils.js
@@ -30,16 +30,28 @@ function getAioLogger(loggerName = 'main', logLevel = 'info') {
 }
 
 function handleExtension(path) {
-    if (path.endsWith('.xlsx')) {
-        return path.replace('.xlsx', '.json');
+    const pidx = path.lastIndexOf('/');
+    const fld = path.substring(0, pidx + 1);
+    let fn = path.substring(pidx + 1);
+
+    if (fn.endsWith('.xlsx')) {
+        fn = fn.replace('.xlsx', '.json');
     }
-    if (path.endsWith('/index.docx')) {
-        return path.substring(0, path.lastIndexOf('/index.docx') + 1);
+    if (fn.toLowerCase() === 'index.docx') {
+        fn = '';
     }
-    if (path.endsWith('.docx')) {
-        return path.substring(0, path.lastIndexOf('.'));
+    if (fn.endsWith('.docx')) {
+        fn = fn.substring(0, fn.lastIndexOf('.'));
     }
-    return path;
+
+    fn = fn
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/[^a-z0-9.]+/g, '-')
+        .replace(/^-|-$/g, '');
+
+    return `${fld}${fn}`;
 }
 
 function getPathFromUrl(url) {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -34,4 +34,13 @@ describe('handleExtension', () => {
     test('docx path', () => {
         expect(utils.handleExtension('/path/to/index.docx')).toEqual('/path/to/');
     });
+    test('files with caps in path', () => {
+        expect(utils.handleExtension('/path/to/Sample.docx')).toEqual('/path/to/sample');
+    });
+    test('files with space in path', () => {
+        expect(utils.handleExtension('/path/to/sample test.docx')).toEqual('/path/to/sample-test');
+    });
+    test('files with space in path', () => {
+        expect(utils.handleExtension('/path/to/Sample_Test.docx')).toEqual('/path/to/sample-test');
+    });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -43,4 +43,10 @@ describe('handleExtension', () => {
     test('files with space in path', () => {
         expect(utils.handleExtension('/path/to/Sample_Test.docx')).toEqual('/path/to/sample-test');
     });
+    test('file in root path', () => {
+        expect(utils.handleExtension('/Sample_Test.docx')).toEqual('/sample-test');
+    });
+    test('file without extension', () => {
+        expect(utils.handleExtension('/Sample_Test')).toEqual('/sample-test');
+    });
 });


### PR DESCRIPTION
Previews are failing with 404 for fils with caps characters.
Updated the filename similar to updates in sidekick
```
/path/to/Sample.docx to /path/to/sample
/path/to/sample test.docx to /path/to/sample-test
/path/to/Sample_Test.docx to /path/to/sample-test
```