### PR TITLE
MWPW-139856 Enable bulk preview / publish for milo

### DIFF
--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -37,6 +37,7 @@ jobs:
           SITE_ROOT_PATH_REX: ${{ vars.SITE_ROOT_PATH_REX }}
           BULK_PREVIEW_CHECK_INTERVAL: ${{ vars.BULK_PREVIEW_CHECK_INTERVAL }}
           MAX_BULK_PREVIEW_CHECKS: ${{ vars.MAX_BULK_PREVIEW_CHECKS }}
+          ENABLE_PREVEW_PUBLISH: ${{ vars.ENABLE_PREVEW_PUBLISH }}
       - name: Checkout
         uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -85,6 +86,7 @@ jobs:
           SITE_ROOT_PATH_REX: ${{ vars.SITE_ROOT_PATH_REX }}
           BULK_PREVIEW_CHECK_INTERVAL: ${{ vars.BULK_PREVIEW_CHECK_INTERVAL }}
           MAX_BULK_PREVIEW_CHECKS: ${{ vars.MAX_BULK_PREVIEW_CHECKS }}
+          ENABLE_PREVEW_PUBLISH: ${{ vars.ENABLE_PREVEW_PUBLISH }}
         uses: adobe/aio-apps-action@2.0.2
         with:
           os: ${{ matrix.os }}

--- a/actions/appConfig.js
+++ b/actions/appConfig.js
@@ -70,6 +70,7 @@ class AppConfig {
         this.configMap.helixAdminApiKeys = this.getJsonFromStr(params.helixAdminApiKeys);
         this.configMap.bulkPreviewCheckInterval = parseInt(params.bulkPreviewCheckInterval || '30', 10);
         this.configMap.maxBulkPreviewChecks = parseInt(params.maxBulkPreviewChecks || '30', 10);
+        this.configMap.enablePreviewPublish = this.getJsonFromStr(params.enablePreviewPublish, []);
         this.extractPrivateKey();
 
         payload.ext = {

--- a/actions/helixUtils.js
+++ b/actions/helixUtils.js
@@ -45,8 +45,17 @@ class HelixUtils {
         return helixAdminApiKeys[repo];
     }
 
+    /**
+     * Checks if the preview is enabled for the main or floodgate site
+     * @param {*} isFloodgate true for copy
+     * @param {*} fgColor floodgate color for the current event
+     * @returns true if preview is enabled
+     */
     canBulkPreviewPublish(isFloodgate = false, fgColor = 'pink') {
-        return !!this.getAdminApiKey(isFloodgate, fgColor);
+        const repo = this.getRepo(isFloodgate, fgColor);
+        const { enablePreviewPublish } = appConfig.getConfig();
+        const repoRegexArr = enablePreviewPublish.map((ps) => new RegExp(`^${ps}$`));
+        return repoRegexArr.find((rx) => rx.test(repo));
     }
 
     /**

--- a/actions/helixUtils.js
+++ b/actions/helixUtils.js
@@ -55,7 +55,7 @@ class HelixUtils {
         const repo = this.getRepo(isFloodgate, fgColor);
         const { enablePreviewPublish } = appConfig.getConfig();
         const repoRegexArr = enablePreviewPublish.map((ps) => new RegExp(`^${ps}$`));
-        return repoRegexArr.find((rx) => rx.test(repo));
+        return true && repoRegexArr.find((rx) => rx.test(repo));
     }
 
     /**

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -26,6 +26,7 @@ application:
           bulkPreviewCheckInterval: $BULK_PREVIEW_CHECK_INTERVAL
           maxBulkPreviewChecks: $MAX_BULK_PREVIEW_CHECKS
           skipInProgressCheck: $SKIP_INPROGRESS_CHECK
+          enablePreviewPublish: $ENABLE_PREVEW_PUBLISH
         actions:
           copy:
             function: actions/copy/copy.js


### PR DESCRIPTION
Bulk preview is enabled for non-authenticated site. Instead of HELIX_ADMIN_API_KEYS a config is added where sites that allows bulk preview or publish is added `ENABLE_PREVEW_PUBLISH=["cc","cc-.*","milo","milo-.*"]`

The values are regular expression based and is checked as `^<value>$`

If the config is set to `[".*"]` this  enable preivew publish for all sites

Resolves: MWPW-139856