### PR TITLE
MWPW-140358 Ignore query-index.xlsx file from promote

### DIFF
--- a/actions/appConfig.js
+++ b/actions/appConfig.js
@@ -44,7 +44,8 @@ class AppConfig {
         payload.fgShareUrl = params.fgShareUrl;
         payload.rootFolder = params.rootFolder;
         payload.fgRootFolder = params.fgRootFolder;
-        payload.promoteIgnorePaths = strToArray(params.promoteIgnorePaths) || ['/.milo', '/.helix', '/metadata.xlsx'];
+        payload.promoteIgnorePaths = strToArray(params.promoteIgnorePaths) || [];
+        payload.promoteIgnorePaths.push('/.milo', '/.helix', '/metadata.xlsx', '*/query-index.xlsx');
         payload.doPublish = params.doPublish;
         payload.driveId = params.driveId;
         payload.fgColor = params.fgColor || 'pink';

--- a/actions/promote/createBatch.js
+++ b/actions/promote/createBatch.js
@@ -20,7 +20,7 @@ const {
     getAuthorizedRequestOption, fetchWithRetry
 } = require('../sharepoint');
 const {
-    getAioLogger, logMemUsage, getInstanceKey, PROMOTE_ACTION
+    getAioLogger, logMemUsage, getInstanceKey, isFilePatternMatched, PROMOTE_ACTION
 } = require('../utils');
 const FgAction = require('../FgAction');
 const FgStatus = require('../fgStatus');
@@ -146,7 +146,7 @@ async function findAndBatchFGFiles(
             for (let di = 0; di < driveItems?.length; di += 1) {
                 const item = driveItems[di];
                 const itemPath = `${item.parentReference.path.replace(pPathRegExp, '')}/${item.name}`;
-                if (!promoteIgnoreList?.includes(itemPath)) {
+                if (!isFilePatternMatched(itemPath, promoteIgnoreList)) {
                     if (item.folder) {
                         // it is a folder
                         fgFolders.push(itemPath);

--- a/actions/utils.js
+++ b/actions/utils.js
@@ -158,6 +158,23 @@ function toUTCStr(dt) {
     return Number.isNaN(ret.getTime()) ? dt : ret.toUTCString();
 }
 
+function isFilePathWithWildcard(filePath, pattern) {
+    if (!filePath || !pattern) {
+        return false;
+    }
+    const escapeRegExp = (string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const wildcardToRegex = (wildcard) => escapeRegExp(wildcard).replace(/\\\*/g, '.*');
+    const regexPattern = new RegExp(`^${wildcardToRegex(pattern)}$`);
+    return regexPattern.test(filePath);
+}
+
+function isFilePatternMatched(filePath, patterns) {
+    if (patterns && Array.isArray(patterns)) {
+        return !!patterns.find((pattern) => isFilePathWithWildcard(filePath, pattern) || isFilePathWithWildcard(filePath, `${pattern}/*`));
+    }
+    return isFilePathWithWildcard(filePath, patterns);
+}
+
 module.exports = {
     errorResponse,
     getAioLogger,
@@ -173,5 +190,7 @@ module.exports = {
     actInProgress,
     getInstanceKey,
     strToArray,
-    toUTCStr
+    toUTCStr,
+    isFilePathWithWildcard,
+    isFilePatternMatched
 };

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -81,3 +81,40 @@ describe('toUTCStr', () => {
         expect(utils.toUTCStr()).toEqual(undefined);
     });
 });
+
+describe('isFilePathWithWildcard', () => {
+    test('matches exact file path', () => {
+        expect(utils.isFilePathWithWildcard('/path/to/file.txt', '/path/to/file.txt')).toBe(true);
+    });
+
+    test('matches file path with wildcard', () => {
+        expect(utils.isFilePathWithWildcard('/path/to/directory/', '/path/to/*')).toBe(true);
+    });
+
+    test('matches file with wildcard extension', () => {
+        expect(utils.isFilePathWithWildcard('file_with_space.txt', '*.txt')).toBe(true);
+    });
+
+    test('match a prefix wild card', () => {
+        expect(utils.isFilePathWithWildcard('/drafts/a/query-index.xlsx', '*/query-index.xlsx')).toBe(true);
+        expect(utils.isFilePathWithWildcard('/drafts/b/query-index.xlsx', '*/query-index.xlsx')).toBe(true);
+        expect(utils.isFilePathWithWildcard('/drafts/b/c/query-index.xlsx', '*/query-index.xlsx')).toBe(true);
+    });
+
+    test('matches dot files', () => {
+        expect(utils.isFilePathWithWildcard('/.milo', '/.milo')).toBe(true);
+        expect(utils.isFilePathWithWildcard('/amilo', '/.milo')).toBe(false);
+    });
+});
+
+describe('isFilePatternMatched', () => {
+    const patterns = ['/.milo', '/.helix', '/metadata.xlsx', '/a/Caps', '*/query-index.xlsx'];
+    test('matches a set of file', () => {
+        expect(utils.isFilePatternMatched('/.helix', patterns)).toBe(true);
+        expect(utils.isFilePatternMatched('/a/Caps', patterns)).toBe(true);
+        expect(utils.isFilePatternMatched('/a/Caps/Test', patterns)).toBe(true);
+        expect(utils.isFilePatternMatched('/a/ACaps/Test', patterns)).toBe(false);
+        expect(utils.isFilePatternMatched('/a/query-index.xlsx', patterns)).toBe(true);
+        expect(utils.isFilePatternMatched('/a/b/query-index.xlsx', patterns)).toBe(true);
+    });
+});


### PR DESCRIPTION
Adding the must ignore paths to promoteIgnorePaths. Since query-index.xlsx can be present in any location. Updated to check paths as pattern

Tested in Milo by executing promote and checking "Ignored from promote". Also compared with a previous run Before - 08/12/2023 05:46:39.787 - Total of 6 Ignored Paths/Files 
After -  13/12/2023  15:44:09.081 -15:43:41.534 = Total of 6 Ignored Paths/Files same as before + 2 for query-index.xlsx

Resolves: MWPW-140358