### PR TITLE
MWPW-140554 FG: pages are LIVE after 'promote only' workflow

### DIFF
--- a/actions/appConfig.js
+++ b/actions/appConfig.js
@@ -16,7 +16,7 @@
  ************************************************************************* */
 
 const crypto = require('crypto');
-const { strToArray, getAioLogger } = require('./utils');
+const { strToArray, strToBool, getAioLogger } = require('./utils');
 const UrlInfo = require('./urlInfo');
 
 // Max activation is 1hrs, set to 2hrs
@@ -221,6 +221,10 @@ class AppConfig {
             return draftsOnly.trim().toLowerCase() !== 'false';
         }
         return draftsOnly;
+    }
+
+    getDoPublish() {
+        return strToBool(this.getPayload().doPublish);
     }
 }
 

--- a/actions/promote/postCopyWorker.js
+++ b/actions/promote/postCopyWorker.js
@@ -42,7 +42,6 @@ async function main(params) {
     const fgAction = new FgAction(`${PROMOTE_BATCH}_${batchNumber}`, params);
     fgAction.init({ ow, skipUserDetails: true, fgStatusParams: { keySuffix: `Batch_${batchNumber}` } });
     const { fgStatus } = fgAction.getActionParams();
-    const payload = appConfig.getPayload();
     const fgRootFolder = appConfig.getSiteFgRootPath();
 
     let respPayload;
@@ -61,7 +60,7 @@ async function main(params) {
             statusMessage: respPayload
         });
 
-        respPayload = await previewPublish(payload.doPublish, batchManager);
+        respPayload = await previewPublish(appConfig.getDoPublish(), batchManager);
         await fgStatus.updateStatusToStateLib({
             status: FgStatus.PROJECT_STATUS.COMPLETED,
             statusMessage: respPayload

--- a/actions/promote/worker.js
+++ b/actions/promote/worker.js
@@ -47,7 +47,6 @@ async function main(params) {
     const fgAction = new FgAction(`${PROMOTE_BATCH}_${batchNumber}`, params);
     fgAction.init({ ow, skipUserDetails: true, fgStatusParams: { keySuffix: `Batch_${batchNumber}` } });
     const { fgStatus } = fgAction.getActionParams();
-    const payload = appConfig.getPayload();
     const fgRootFolder = appConfig.getSiteFgRootPath();
 
     let respPayload;
@@ -73,7 +72,7 @@ async function main(params) {
         });
         respPayload = 'Promote files';
         logger.info(respPayload);
-        respPayload = await promoteFloodgatedFiles(payload.doPublish, batchManager);
+        respPayload = await promoteFloodgatedFiles(batchManager);
         respPayload = `Promoted files ${JSON.stringify(respPayload)}`;
         await fgStatus.updateStatusToStateLib({
             status: FgStatus.PROJECT_STATUS.IN_PROGRESS,
@@ -130,7 +129,7 @@ async function promoteCopy(srcPath, destinationFolder) {
     return copySuccess;
 }
 
-async function promoteFloodgatedFiles(doPublish, batchManager) {
+async function promoteFloodgatedFiles(batchManager) {
     const logger = getAioLogger();
 
     async function promoteFile(batchItem) {

--- a/actions/utils.js
+++ b/actions/utils.js
@@ -153,6 +153,13 @@ function strToArray(val) {
     return val;
 }
 
+function strToBool(val) {
+    if (val !== undefined && typeof val === 'string') {
+        return val.trim().toLowerCase() === 'true';
+    }
+    return val;
+}
+
 function toUTCStr(dt) {
     const ret = new Date(dt);
     return Number.isNaN(ret.getTime()) ? dt : ret.toUTCString();
@@ -192,5 +199,6 @@ module.exports = {
     strToArray,
     toUTCStr,
     isFilePathWithWildcard,
-    isFilePatternMatched
+    isFilePatternMatched,
+    strToBool
 };

--- a/test/appConfig.test.js
+++ b/test/appConfig.test.js
@@ -95,6 +95,7 @@ describe('appConfig', () => {
             }
         });
         expect(appConfig.isDraftOnly()).toBeTruthy();
+        expect(appConfig.getDoPublish()).not.toBeTruthy();
 
         appConfig.removePayload();
         expect(() => appConfig.getPayload()).toThrow();

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -118,3 +118,18 @@ describe('isFilePatternMatched', () => {
         expect(utils.isFilePatternMatched('/a/b/query-index.xlsx', patterns)).toBe(true);
     });
 });
+
+describe('strToBool', () => {
+    test('Check for a set of true and false inputs', () => {
+        expect(utils.strToBool('true')).toBeTruthy();
+        expect(utils.strToBool('TRUE')).toBeTruthy();
+        expect(utils.strToBool(true)).toBeTruthy();
+        expect(utils.strToBool('false')).not.toBeTruthy();
+        expect(utils.strToBool('FALSE')).not.toBeTruthy();
+        expect(utils.strToBool(false)).not.toBeTruthy();
+        expect(utils.strToBool('something')).not.toBeTruthy();
+        expect(utils.strToBool('')).not.toBeTruthy();
+        expect(utils.strToBool(null)).not.toBeTruthy();
+        expect(utils.strToBool(undefined)).not.toBeTruthy();
+    });
+});


### PR DESCRIPTION
String of "false" is passed hence a not null check is not suitable for this. Updated to check as a string as well.

Resolves: MWPW-140554