### PR TITLE
MWPW-141630 Support for video file copy

### DIFF
--- a/actions/utils.js
+++ b/actions/utils.js
@@ -67,7 +67,7 @@ function getDocPathFromUrl(url) {
         path = path.slice(0, -5);
         return `${path}.xlsx`;
     }
-    if (path.endsWith('.svg') || path.endsWith('.pdf')) {
+    if (path.endsWith('.svg') || path.endsWith('.pdf') || path.endsWith('.mp4')) {
         return path;
     }
     if (path.endsWith('/')) {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -150,5 +150,7 @@ describe('getDocPathFromUrl', () => {
             .toEqual('/drafts/test/samplevimg.svg');
         expect(utils.getDocPathFromUrl('https://main--cc-pink--adobecom.hlx.page/drafts/test/axsizzle-marquee.mp4'))
             .toEqual('/drafts/test/axsizzle-marquee.mp4');
+        expect(utils.getDocPathFromUrl('https://main--cc-pink--adobecom.hlx.page/drafts/test/axsizzle-marquee.mp4#_autoplay'))
+            .toEqual('/drafts/test/axsizzle-marquee.mp4');
     });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -133,3 +133,22 @@ describe('strToBool', () => {
         expect(utils.strToBool(undefined)).not.toBeTruthy();
     });
 });
+
+describe('getDocPathFromUrl', () => {
+    test('Check for a set of true and false inputs', () => {
+        expect(utils.getDocPathFromUrl('https://main--cc-pink--adobecom.hlx.page/drafts/test/samplepage'))
+            .toEqual('/drafts/test/samplepage.docx');
+        expect(utils.getDocPathFromUrl('https://main--cc-pink--adobecom.hlx.page/drafts/test/'))
+            .toEqual('/drafts/test/index.docx');
+        expect(utils.getDocPathFromUrl('https://main--cc-pink--adobecom.hlx.page/drafts/test/samplesheet.json'))
+            .toEqual('/drafts/test/samplesheet.xlsx');
+        expect(utils.getDocPathFromUrl('https://main--cc-pink--adobecom.hlx.page/drafts/test/samplehtmlpage.html'))
+            .toEqual('/drafts/test/samplehtmlpage.docx');
+        expect(utils.getDocPathFromUrl('https://main--cc-pink--adobecom.hlx.page/drafts/test/samplepdf.pdf'))
+            .toEqual('/drafts/test/samplepdf.pdf');
+        expect(utils.getDocPathFromUrl('https://main--cc-pink--adobecom.hlx.page/drafts/test/samplevimg.svg'))
+            .toEqual('/drafts/test/samplevimg.svg');
+        expect(utils.getDocPathFromUrl('https://main--cc-pink--adobecom.hlx.page/drafts/test/axsizzle-marquee.mp4'))
+            .toEqual('/drafts/test/axsizzle-marquee.mp4');
+    });
+});


### PR DESCRIPTION
Video file (.mp4) preview contains the extension and same needs to used while generating path (Similar to SVG and PDF).


Tested by placing a mp4 (small case with hypens) in www (CC), previewing and added to floodgate project xlsx. On copy the file was copied over from www to www-pink
<img width="452" alt="image" src="https://github.com/adobecom/milo-fg/assets/125877471/52427b61-3f5e-417e-91b0-58484a435ad8">

Resolves: MWPW-141630