### PR TITLE
MWPW-152337: Reads site uri from the action payload

### DIFF
--- a/actions/appConfig.js
+++ b/actions/appConfig.js
@@ -54,9 +54,10 @@ class AppConfig {
         payload.draftsOnly = params.draftsOnly;
         payload.enablePromote = params.enablePromote;
         payload.enableDelete = params.enableDelete;
+        payload.spSite = params.spSite;
 
         // These are from configs and not activation related
-        this.configMap.fgSite = params.spSite || params.fgSite;
+        this.configMap.fgSite = payload.spSite || params.fgSite;
         this.configMap.fgClientId = params.fgClientId;
         this.configMap.fgAuthority = params.fgAuthority;
         this.configMap.clientId = params.clientId;

--- a/actions/appConfig.js
+++ b/actions/appConfig.js
@@ -56,7 +56,7 @@ class AppConfig {
         payload.enableDelete = params.enableDelete;
 
         // These are from configs and not activation related
-        this.configMap.fgSite = params.fgSite;
+        this.configMap.fgSite = params.spSite || params.fgSite;
         this.configMap.fgClientId = params.fgClientId;
         this.configMap.fgAuthority = params.fgAuthority;
         this.configMap.clientId = params.clientId;

--- a/test/appConfig.test.js
+++ b/test/appConfig.test.js
@@ -26,7 +26,7 @@ jest.mock('crypto', () => ({
 
 let params = {
     spToken: 'eyJ0eXAi',
-    adminPageUri: 'https://floodgateui--milo--adobecom.hlx.page/tools/floodgate?ref=floodgateui&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo' + 
+    adminPageUri: 'https://floodgateui--milo--adobecom.hlx.page/tools/floodgate?ref=floodgateui&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo' +
     '&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx' +
     '%3Fsourcedoc%3D%257B442C005E-8094-4EB8-A78F-48BF427A04ED%257D%26file%3DBook5.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue',
     projectExcelPath: '/drafts/floodgate/projects/raga/fgtest1.xlsx',
@@ -38,7 +38,8 @@ let params = {
     doPublish: 'false',
     driveId: 'drive',
     fgColor: 'purple',
-    draftsOnly: 'true'
+    draftsOnly: 'true',
+    spSite: 'https://graph.microsoft.com/v1.0/sites/site.sharepoint.com,d21',
 };
 // Add config
 params = {


### PR DESCRIPTION
If `spSite` param is not available, falls back to the FG_SITE value setup in the milo-fg env variable.

Floodgate UI has been updated as part of the following commit to send the site URI data.
https://github.com/adobecom/milo/commit/a8b41ce85926bbdbfe62eaa556ae1b4f407ced4b 

Resolves: [MWPW-152337](https://jira.corp.adobe.com/browse/MWPW-152337)