### PR TITLE
MWPW-152581 Retain version history on promote

### DIFF
--- a/actions/fgPromoteActionHelper.js
+++ b/actions/fgPromoteActionHelper.js
@@ -93,50 +93,18 @@ class FgPromoteActionHelper {
         }
     }
 
-    /**
-     * Copies the Floodgated files back to the main content tree.
-     * Creates intermediate folders if needed.
-     */
-    async promoteCopy(srcPath, destinationFolder, { sharepoint, sp }) {
-        const { baseURI } = sp.api.file.copy;
-        const rootFolder = baseURI.split('/').pop();
-        const payload = { ...sp.api.file.copy.payload, parentReference: { path: `${rootFolder}${destinationFolder}` } };
-        const options = await sharepoint.getAuthorizedRequestOption({
-            method: sp.api.file.copy.method,
-            body: JSON.stringify(payload),
-        });
-
-        // copy source is the pink directory for promote
-        const copyStatusInfo = await sharepoint.fetchWithRetry(`${sp.api.file.copy.fgBaseURI}${srcPath}:/copy?@microsoft.graph.conflictBehavior=replace`, options);
-        const statusUrl = copyStatusInfo.headers.get('Location');
-        let copySuccess = false;
-        let copyStatusJson = {};
-        while (statusUrl && !copySuccess && copyStatusJson.status !== 'failed') {
-            // eslint-disable-next-line no-await-in-loop
-            const status = await sharepoint.fetchWithRetry(statusUrl);
-            if (status.ok) {
-                // eslint-disable-next-line no-await-in-loop
-                copyStatusJson = await status.json();
-                copySuccess = copyStatusJson.status === 'completed';
-            }
-        }
-        return copySuccess;
-    }
-
     async promoteFloodgatedFiles(batchManager, appConfig) {
         const logger = getAioLogger();
         const sharepoint = new Sharepoint(appConfig);
         const sp = await appConfig.getSpConfig();
         // Pre check Access Token
         await sharepoint.getSharepointAuth().getAccessToken();
-        const { promoteCopy } = this;
 
         async function promoteFile(batchItem) {
             const { fileDownloadUrl, filePath, mimeType } = batchItem.file;
             const status = { success: false, srcPath: filePath };
             try {
                 let promoteSuccess = false;
-                const destinationFolder = `${filePath.substring(0, filePath.lastIndexOf('/'))}`;
                 const content = await sharepoint.getFileUsingDownloadUrl(fileDownloadUrl);
                 const uploadStatus = await sharepoint.uploadFileByPath(sp, filePath, { content, mimeType });
                 if (uploadStatus) {

--- a/test/sharepoint.test.js
+++ b/test/sharepoint.test.js
@@ -64,7 +64,12 @@ describe('sharepoint', () => {
                     },
                     update: {
                         fgBaseURI,
-                    }
+                    },
+                    upload: {
+                        baseURI,
+                        fgBaseURI,
+                        method: 'PUT',
+                    },
                 },
                 excel: {
                     get: { baseItemsURI: 'https://gql/base' },
@@ -194,13 +199,13 @@ describe('sharepoint', () => {
         );
     });
 
-    it('should return a blob object when given a valid download URL and authorized request options', async () => {
+    it('should return a buffer object when given a valid download URL and authorized request options', async () => {
         // Mock the necessary dependencies
         const sharepoint = new Sharepoint(appConfig);
         const downloadUrl = '/file/download';
 
         // Mock the fetchWithRetry method
-        sharepoint.fetchWithRetry = jest.fn().mockResolvedValue({ blob: () => 'Test' });
+        sharepoint.fetchWithRetry = jest.fn().mockResolvedValue({ buffer: () => 'Test' });
 
         // Invoke the method and assert the result
         const result = await sharepoint.getFileUsingDownloadUrl(downloadUrl);
@@ -566,5 +571,16 @@ describe('sharepoint', () => {
         expect(response.status).toBe(200);
         const data = await response.json();
         expect(data).toEqual({});
+    });
+
+    it('uploads a file and returns update status', async () => {
+        const sharepoint = new Sharepoint(appConfig);
+        jest.spyOn(sharepoint, 'executeGQL').mockResolvedValueOnce({ 'id': 'SP10' });
+        const options = {
+            content: Buffer.from('Testing'),
+            mime: 'text/plain',
+        }
+        const response = await sharepoint.uploadFileByPath(appConfig.getSpConfig(), '/drafts/file.txt', options);
+        expect(response.id).toEqual('SP10');
     });
 });


### PR DESCRIPTION
During promote use the upload content api instead of copy as the version history is lost.

The else block for lock file can also be removed as another PR. We still get lock file errors.
(Remove else of await sharepoint.saveFile(content, filePath) )

Test: 
<img width="348" alt="image" src="https://github.com/adobecom/milo-fg/assets/125877471/eb6acb14-a9a2-45fb-8fb0-fc5c64ded030">

