### PR TITLE
MWPW-160240 rootFolder parameter is obtained from config.json and not passed in input

### DIFF
--- a/actions/copy/copy.js
+++ b/actions/copy/copy.js
@@ -27,7 +27,7 @@ async function main(args) {
     const logger = getAioLogger();
     let respPayload;
     const valParams = {
-        statParams: ['rootFolder', 'projectExcelPath'],
+        statParams: ['projectExcelPath'],
         actParams: ['adminPageUri'],
         checkUser: true,
         checkStatus: true,


### PR DESCRIPTION

rootFolder parameter is obtained from config.json and not passed in input

<img width="920" alt="image" src="https://github.com/user-attachments/assets/29a7bb3c-d61e-4cba-af14-e076b89ffd2c" />
